### PR TITLE
ci(pr): add compact job summaries to PR CI workflow

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -39,19 +39,39 @@ jobs:
         run: pnpm --filter taurent exec playwright install --with-deps chromium
 
       - name: Check app versions
+        id: check-versions
         run: node scripts/ci/check-versions.mjs
 
       - name: Lint
+        id: lint
         run: pnpm lint
 
       - name: Typecheck
+        id: typecheck
         run: pnpm typecheck
 
       - name: Unit tests
+        id: unit-tests
         run: pnpm test:unit
 
       - name: Renderer e2e
+        id: renderer-e2e
         run: pnpm desktop:renderer:e2e
+
+      - name: Write summary
+        if: always()
+        env:
+          CI_JOB_KIND: js-quality
+          CI_JOB_RESULT: ${{ job.status }}
+          CI_STEP_OUTCOMES: >-
+            {
+              "check-versions": "${{ steps.check-versions.outcome }}",
+              "lint": "${{ steps.lint.outcome }}",
+              "typecheck": "${{ steps.typecheck.outcome }}",
+              "unit-tests": "${{ steps.unit-tests.outcome }}",
+              "renderer-e2e": "${{ steps.renderer-e2e.outcome }}"
+            }
+        run: node scripts/ci/write-pr-ci-summary.mjs
 
   rust-quality:
     name: Rust Quality
@@ -76,13 +96,39 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf build-essential curl wget file
 
       - name: Rustfmt check
+        id: rustfmt-check
         run: cargo fmt --all --check
 
-      - name: Cargo check
-        run: cargo check --workspace --locked -p qb-core && cargo check --workspace --locked --features desktop -p qb-tauri
+      - name: Cargo check (core)
+        id: cargo-check-core
+        run: cargo check --workspace --locked -p qb-core
 
-      - name: Clippy
-        run: cargo clippy --workspace --all-targets --locked -p qb-core && cargo clippy --workspace --all-targets --locked --features desktop -p qb-tauri
+      - name: Cargo check (tauri)
+        id: cargo-check-tauri
+        run: cargo check --workspace --locked --features desktop -p qb-tauri
+
+      - name: Clippy (core)
+        id: clippy-core
+        run: cargo clippy --workspace --all-targets --locked -p qb-core
+
+      - name: Clippy (tauri)
+        id: clippy-tauri
+        run: cargo clippy --workspace --all-targets --locked --features desktop -p qb-tauri
+
+      - name: Write summary
+        if: always()
+        env:
+          CI_JOB_KIND: rust-quality
+          CI_JOB_RESULT: ${{ job.status }}
+          CI_STEP_OUTCOMES: >-
+            {
+              "rustfmt-check": "${{ steps.rustfmt-check.outcome }}",
+              "cargo-check-core": "${{ steps.cargo-check-core.outcome }}",
+              "cargo-check-tauri": "${{ steps.cargo-check-tauri.outcome }}",
+              "clippy-core": "${{ steps.clippy-core.outcome }}",
+              "clippy-tauri": "${{ steps.clippy-tauri.outcome }}"
+            }
+        run: node scripts/ci/write-pr-ci-summary.mjs
 
   native-smoke:
     name: Desktop Tauri Smoke (Linux)
@@ -121,9 +167,11 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf build-essential curl wget file libxdo-dev libssl-dev webkit2gtk-driver xvfb dbus-x11 at-spi2-core
 
       - name: Build desktop Tauri app for smoke
+        id: build-smoke
         run: pnpm --filter taurent tauri build --no-bundle --features webdriver
 
       - name: Run native Tauri smoke
+        id: run-smoke
         env:
           GDK_BACKEND: x11
           NO_AT_BRIDGE: '1'
@@ -131,6 +179,14 @@ jobs:
           LIBGL_ALWAYS_SOFTWARE: '1'
         run: |
           xvfb-run -a --server-args="-screen 0 1280x1024x24 -ac +extension GLX +render -noreset" dbus-run-session -- pnpm --filter taurent exec tsx scripts/e2e/runner.ts --skip-build
+
+      - name: Write summary
+        if: always()
+        env:
+          CI_JOB_KIND: native-smoke
+          CI_JOB_RESULT: ${{ job.status }}
+          CI_PERF_ARTIFACT_PATH: artifacts/desktop/perf/native-smoke.json
+        run: node scripts/ci/write-pr-ci-summary.mjs
 
       - name: Upload native Tauri diagnostics
         if: failure()
@@ -147,3 +203,22 @@ jobs:
           name: desktop-tauri-perf
           path: artifacts/desktop/perf/native-smoke.json
           if-no-files-found: warn
+
+  pr-ci-summary:
+    name: PR CI Summary
+    needs: [js-quality, rust-quality, native-smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Write aggregate summary
+        env:
+          CI_JOB_KIND: aggregate
+          CI_JS_RESULT: ${{ needs.js-quality.result }}
+          CI_RUST_RESULT: ${{ needs.rust-quality.result }}
+          CI_SMOKE_RESULT: ${{ needs.native-smoke.result }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/ci/write-pr-ci-summary.mjs

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ci:local:full": "pnpm ci:local && pnpm ci:rust && pnpm --filter taurent build && pnpm --filter taurent-mobile build && pnpm mobile:test && pnpm desktop:renderer:e2e",
     "ci:pre-commit": "node scripts/ci/check-versions.mjs && node apps/desktop/scripts/icons/sync-tray-rgba.mjs && cargo fmt --all --check && pnpm lint",
     "ci:pre-push": "pnpm ci:local",
-    "test:scripts": "node --test scripts/version-app.test.mjs scripts/ci/check-versions.test.mjs scripts/release/prepare-release-assets.test.mjs",
+    "test:scripts": "node --test scripts/version-app.test.mjs scripts/ci/check-versions.test.mjs scripts/ci/write-pr-ci-summary.test.mjs scripts/release/prepare-release-assets.test.mjs",
     "version:app": "node scripts/version-app.mjs",
     "postinstall": "simple-git-hooks"
   },

--- a/scripts/ci/codemap.md
+++ b/scripts/ci/codemap.md
@@ -6,7 +6,9 @@ CI validation scripts covering two concerns: version consistency across workspac
 
 ## Design
 
-Two independent entrypoints: `check-versions.mjs` (Node) and `runs-coverage.sh` (shell). They share no library, run in isolation, and exit non-zero on failure so CI fails the build.
+Three independent entrypoints: `check-versions.mjs` (Node), `runs-coverage.sh` (shell), and `write-pr-ci-summary.mjs` (Node). They share no library, run in isolation, and exit non-zero on failure so CI fails the build.
+
+- `write-pr-ci-summary.mjs`: Writes compact Markdown job summaries to `GITHUB_STEP_SUMMARY` for `pr-ci.yml` jobs. Supports js-quality, rust-quality, native-smoke, and aggregate lanes.
 
 ## Flow
 

--- a/scripts/ci/write-pr-ci-summary.mjs
+++ b/scripts/ci/write-pr-ci-summary.mjs
@@ -19,6 +19,7 @@ export function statusEmoji(status) {
 
 export function escapeMarkdown(str) {
   return String(str)
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/\*/g, '\\*')
     .replace(/`/g, '\\`')

--- a/scripts/ci/write-pr-ci-summary.mjs
+++ b/scripts/ci/write-pr-ci-summary.mjs
@@ -1,0 +1,213 @@
+import { appendFileSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+export function statusEmoji(status) {
+  switch (status) {
+    case 'success':
+      return '✅';
+    case 'failure':
+      return '❌';
+    case 'skipped':
+      return '⏭️';
+    case 'cancelled':
+      return '🚫';
+    default:
+      return '❔';
+  }
+}
+
+export function escapeMarkdown(str) {
+  return String(str)
+    .replace(/\|/g, '\\|')
+    .replace(/\*/g, '\\*')
+    .replace(/`/g, '\\`')
+    .replace(/\[/g, '\\[');
+}
+
+const JS_STEP_NAMES = {
+  'check-versions': 'Check app versions',
+  lint: 'Lint',
+  typecheck: 'Typecheck',
+  'unit-tests': 'Unit tests',
+  'renderer-e2e': 'Renderer e2e',
+};
+
+const RUST_STEP_NAMES = {
+  'rustfmt-check': 'Rustfmt check',
+  'cargo-check-core': 'Cargo check (core)',
+  'cargo-check-tauri': 'Cargo check (tauri)',
+  'clippy-core': 'Clippy (core)',
+  'clippy-tauri': 'Clippy (tauri)',
+};
+
+function parseStepOutcomes() {
+  const raw = process.env.CI_STEP_OUTCOMES ?? '{}';
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (err) {
+    console.error(`write-pr-ci-summary: invalid CI_STEP_OUTCOMES JSON: ${err.message}`);
+    return {};
+  }
+}
+
+export function buildStepRows(stepNames, outcomes) {
+  return Object.entries(stepNames).map(([id, displayName]) => {
+    const outcome = outcomes[id] ?? 'skipped';
+    return `| ${escapeMarkdown(displayName)} | ${statusEmoji(outcome)} ${outcome} |`;
+  });
+}
+
+export function writeJsQualitySummary() {
+  const jobResult = process.env.CI_JOB_RESULT ?? 'unknown';
+  const outcomes = parseStepOutcomes();
+  const rows = buildStepRows(JS_STEP_NAMES, outcomes);
+
+  return [
+    '## JS Quality Summary',
+    '',
+    '| Step | Outcome |',
+    '|------|---------|',
+    ...rows,
+    '',
+    `**Job result: ${statusEmoji(jobResult)} ${jobResult}**`,
+    '',
+  ].join('\n');
+}
+
+export function writeRustQualitySummary() {
+  const jobResult = process.env.CI_JOB_RESULT ?? 'unknown';
+  const outcomes = parseStepOutcomes();
+  const rows = buildStepRows(RUST_STEP_NAMES, outcomes);
+
+  return [
+    '## Rust Quality Summary',
+    '',
+    '| Step | Outcome |',
+    '|------|---------|',
+    ...rows,
+    '',
+    `**Job result: ${statusEmoji(jobResult)} ${jobResult}**`,
+    '',
+  ].join('\n');
+}
+
+export function writeNativeSmokeSummary() {
+  const jobResult = process.env.CI_JOB_RESULT ?? 'unknown';
+  const perfPath = process.env.CI_PERF_ARTIFACT_PATH;
+
+  let scenario = 'N/A';
+  let duration = 'N/A';
+  let syncPass = 'N/A';
+  let backendChecks = 'N/A';
+
+  if (!perfPath) {
+    duration = 'No perf data — artifact not produced';
+  } else {
+    let raw;
+    try {
+      raw = readFileSync(perfPath, 'utf8');
+    } catch (err) {
+      console.error(`write-pr-ci-summary: cannot read perf artifact: ${err.message}`);
+      duration = 'No perf data — artifact not produced';
+    }
+    if (raw !== undefined) {
+      try {
+        const data = JSON.parse(raw);
+        scenario = data.scenario ?? 'N/A';
+        if (typeof data.durationMs === 'number') {
+          duration = `${(data.durationMs / 1000).toFixed(1)}s`;
+        }
+        if (data.sync && typeof data.sync.pass === 'boolean') {
+          syncPass = data.sync.pass ? '✅' : '❌';
+        }
+        if (Array.isArray(data.backendChecks)) {
+          backendChecks = data.backendChecks.length;
+        }
+      } catch (err) {
+        console.error(`write-pr-ci-summary: cannot parse perf artifact: ${err.message}`);
+        duration = 'Perf data unreadable';
+      }
+    }
+  }
+
+  return [
+    '## Desktop Tauri Smoke Summary',
+    '',
+    '| Metric | Value |',
+    '|--------|-------|',
+    `| Scenario | ${escapeMarkdown(scenario)} |`,
+    `| Duration | ${escapeMarkdown(duration)} |`,
+    `| Sync Pass | ${syncPass} |`,
+    `| Backend Checks | ${backendChecks} |`,
+    '| Artifacts | desktop-tauri-e2e-artifacts, desktop-tauri-perf |',
+    '',
+    `**Job result: ${statusEmoji(jobResult)} ${jobResult}**`,
+    '',
+  ].join('\n');
+}
+
+export function writeAggregateSummary() {
+  const jsResult = process.env.CI_JS_RESULT ?? 'skipped';
+  const rustResult = process.env.CI_RUST_RESULT ?? 'skipped';
+  const smokeResult = process.env.CI_SMOKE_RESULT ?? 'skipped';
+  const runId = process.env.GITHUB_RUN_ID ?? '';
+  const repo = process.env.GITHUB_REPOSITORY ?? '';
+
+  const lines = [
+    '## PR CI Overview',
+    '',
+    '| Lane | Result |',
+    '|------|--------|',
+    `| JS Quality | ${statusEmoji(jsResult)} ${jsResult} |`,
+    `| Rust Quality | ${statusEmoji(rustResult)} ${rustResult} |`,
+    `| Desktop Tauri Smoke (Linux) | ${statusEmoji(smokeResult)} ${smokeResult} |`,
+    '',
+  ];
+
+  if (runId && repo) {
+    lines.push(`[View artifacts](https://github.com/${repo}/actions/runs/${runId})`, '');
+  }
+
+  return lines.join('\n');
+}
+
+function main() {
+  const kind = process.env.CI_JOB_KIND;
+  const output = process.env.GITHUB_STEP_SUMMARY;
+
+  try {
+    let md = '';
+    switch (kind) {
+      case 'js-quality':
+        md = writeJsQualitySummary();
+        break;
+      case 'rust-quality':
+        md = writeRustQualitySummary();
+        break;
+      case 'native-smoke':
+        md = writeNativeSmokeSummary();
+        break;
+      case 'aggregate':
+        md = writeAggregateSummary();
+        break;
+      default:
+        throw new Error(`Unknown CI_JOB_KIND: ${kind}`);
+    }
+    if (output) {
+      appendFileSync(output, `${md}\n`);
+    } else {
+      process.stdout.write(`${md}\n`);
+    }
+  } catch (err) {
+    console.error(`write-pr-ci-summary: ${err.message}`);
+    process.exitCode = 1;
+  }
+}
+
+const invokedPath = process.argv[1];
+const isMain = invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url);
+if (isMain) {
+  main();
+}

--- a/scripts/ci/write-pr-ci-summary.test.mjs
+++ b/scripts/ci/write-pr-ci-summary.test.mjs
@@ -1,0 +1,205 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { escapeMarkdown } from './write-pr-ci-summary.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const scriptPath = resolve(repoRoot, 'scripts/ci/write-pr-ci-summary.mjs');
+
+function runSummary(env = {}) {
+  return spawnSync(process.execPath, [scriptPath], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env, GITHUB_STEP_SUMMARY: '' },
+    encoding: 'utf8',
+  });
+}
+
+test('JS quality summary shows all steps with success emojis', () => {
+  const result = runSummary({
+    CI_JOB_KIND: 'js-quality',
+    CI_JOB_RESULT: 'success',
+    CI_STEP_OUTCOMES: JSON.stringify({
+      'check-versions': 'success',
+      lint: 'success',
+      typecheck: 'success',
+      'unit-tests': 'success',
+      'renderer-e2e': 'success',
+    }),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /## JS Quality Summary/);
+  assert.match(result.stdout, /Check app versions\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /Lint\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /Typecheck\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /Unit tests\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /Renderer e2e\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /\*\*Job result: ✅ success\*\*/);
+});
+
+test('JS quality summary maps mixed step outcomes to correct emojis', () => {
+  const result = runSummary({
+    CI_JOB_KIND: 'js-quality',
+    CI_JOB_RESULT: 'failure',
+    CI_STEP_OUTCOMES: JSON.stringify({
+      'check-versions': 'success',
+      lint: 'failure',
+      typecheck: 'success',
+      'unit-tests': 'success',
+      'renderer-e2e': 'success',
+    }),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Check app versions\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /Lint\s*\|\s*❌\sfailure\s*\|/);
+  assert.match(result.stdout, /Typecheck\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /Unit tests\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /Renderer e2e\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /\*\*Job result: ❌ failure\*\*/);
+});
+
+test('Rust quality summary shows all steps with success emojis', () => {
+  const result = runSummary({
+    CI_JOB_KIND: 'rust-quality',
+    CI_JOB_RESULT: 'success',
+    CI_STEP_OUTCOMES: JSON.stringify({
+      'rustfmt-check': 'success',
+      'cargo-check-core': 'success',
+      'cargo-check-tauri': 'success',
+      'clippy-core': 'success',
+      'clippy-tauri': 'success',
+    }),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /## Rust Quality Summary/);
+  assert.match(result.stdout, /Rustfmt check\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /Cargo check \(core\)\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /Cargo check \(tauri\)\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /Clippy \(core\)\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /Clippy \(tauri\)\s*\|\s*✅\s*success\s*\|/);
+  assert.match(result.stdout, /\*\*Job result: ✅ success\*\*/);
+});
+
+test('Aggregate summary shows all lanes passing with artifact link', () => {
+  const result = runSummary({
+    CI_JOB_KIND: 'aggregate',
+    CI_JS_RESULT: 'success',
+    CI_RUST_RESULT: 'success',
+    CI_SMOKE_RESULT: 'success',
+    GITHUB_RUN_ID: '12345',
+    GITHUB_REPOSITORY: 'racos-dev/taurent',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /## PR CI Overview/);
+  assert.match(result.stdout, /JS Quality\s*\|\s*✅\ssuccess\s*\|/);
+  assert.match(result.stdout, /Rust Quality\s*\|\s*✅\ssuccess\s*\|/);
+  assert.match(result.stdout, /Desktop Tauri Smoke \(Linux\)\s*\|\s*✅\ssuccess\s*\|/);
+  assert.match(
+    result.stdout,
+    /\[View artifacts\]\(https:\/\/github\.com\/racos-dev\/taurent\/actions\/runs\/12345\)/,
+  );
+});
+
+test('Aggregate summary shows skipped smoke when prior lane failed', () => {
+  const result = runSummary({
+    CI_JOB_KIND: 'aggregate',
+    CI_JS_RESULT: 'success',
+    CI_RUST_RESULT: 'failure',
+    CI_SMOKE_RESULT: 'skipped',
+    GITHUB_RUN_ID: '999',
+    GITHUB_REPOSITORY: 'racos-dev/taurent',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /JS Quality\s*\|\s*✅\ssuccess\s*\|/);
+  assert.match(result.stdout, /Rust Quality\s*\|\s*❌\sfailure\s*\|/);
+  assert.match(result.stdout, /Desktop Tauri Smoke \(Linux\)\s*\|\s*⏭️\sskipped\s*\|/);
+});
+
+test('Native smoke summary reads perf artifact fields when JSON is valid', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'taurent-pr-ci-summary-perf-'));
+  const perfPath = resolve(dir, 'native-smoke.json');
+  writeFileSync(
+    perfPath,
+    JSON.stringify({
+      runtime: 'native-tauri-smoke',
+      scenario: 'small-100',
+      success: true,
+      durationMs: 12345,
+      timings: {
+        appLaunchMs: 1000,
+        serverConnectMs: 500,
+        tableVisibleMs: 2000,
+        interactionPhaseMs: 8000,
+      },
+      backendChecks: ['a', 'b', 'c', 'd', 'e'],
+      sync: { pass: true, blockers: [] },
+    }),
+  );
+
+  const result = runSummary({
+    CI_JOB_KIND: 'native-smoke',
+    CI_JOB_RESULT: 'success',
+    CI_PERF_ARTIFACT_PATH: perfPath,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /## Desktop Tauri Smoke Summary/);
+  assert.match(result.stdout, /Scenario\s*\|\s*small-100\s*\|/);
+  assert.match(result.stdout, /Duration\s*\|\s*12\.3s\s*\|/);
+  assert.match(result.stdout, /Sync Pass\s*\|\s*✅\s*\|/);
+  assert.match(result.stdout, /Backend Checks\s*\|\s*5\s*\|/);
+  assert.match(result.stdout, /Artifacts\s*\|\s*desktop-tauri-e2e-artifacts, desktop-tauri-perf\s*\|/);
+  assert.match(result.stdout, /\*\*Job result: ✅ success\*\*/);
+});
+
+test('Native smoke summary handles missing perf artifact gracefully', () => {
+  const result = runSummary({
+    CI_JOB_KIND: 'native-smoke',
+    CI_JOB_RESULT: 'failure',
+    CI_PERF_ARTIFACT_PATH: '/does/not/exist/native-smoke.json',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Duration\s*\|\s*No perf data — artifact not produced\s*\|/);
+  assert.match(result.stdout, /Sync Pass\s*\|\s*N\/A\s*\|/);
+  assert.match(result.stdout, /Backend Checks\s*\|\s*N\/A\s*\|/);
+});
+
+test('Native smoke summary handles malformed perf JSON', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'taurent-pr-ci-summary-perf-bad-'));
+  const perfPath = resolve(dir, 'native-smoke.json');
+  writeFileSync(perfPath, '{this is definitely not valid JSON');
+
+  const result = runSummary({
+    CI_JOB_KIND: 'native-smoke',
+    CI_JOB_RESULT: 'failure',
+    CI_PERF_ARTIFACT_PATH: perfPath,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Duration\s*\|\s*Perf data unreadable\s*\|/);
+  assert.match(result.stdout, /Sync Pass\s*\|\s*N\/A\s*\|/);
+  assert.match(result.stdout, /Backend Checks\s*\|\s*N\/A\s*\|/);
+});
+
+test('escapeMarkdown escapes pipe, asterisk, backtick, and bracket', () => {
+  assert.equal(escapeMarkdown('a|b'), 'a\\|b');
+  assert.equal(escapeMarkdown('a*b'), 'a\\*b');
+  assert.equal(escapeMarkdown('a`b'), 'a\\`b');
+  assert.equal(escapeMarkdown('a[b'), 'a\\[b');
+  assert.equal(escapeMarkdown('no special chars'), 'no special chars');
+  assert.equal(escapeMarkdown(''), '');
+  assert.equal(
+    escapeMarkdown('mixed | * ` [ characters'),
+    'mixed \\| \\* \\` \\[ characters',
+  );
+});


### PR DESCRIPTION
- Add write-pr-ci-summary.mjs helper for GITHUB_STEP_SUMMARY output
- Add write-pr-ci-summary.test.mjs with 9 unit tests
- Add step IDs and if:always() summary steps to all three lane jobs
- Split Rust check/clippy into separate steps for granular tracking
- Add aggregate pr-ci-summary job with artifact links
- Update test:scripts and ci/codemap.md