### PR TITLE
feat(desktop): add Tauri auto-updater with signed releases

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,8 +22,6 @@ jobs:
         include:
           - language: javascript-typescript
             build-mode: none
-          - language: rust
-            build-mode: none
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -139,6 +139,7 @@ jobs:
           cargo clippy --workspace --all-targets --locked --features mobile -p qb-tauri
 
   desktop-build:
+    environment: release
     name: Desktop Build (${{ matrix.name }})
     needs: release-preflight
     runs-on: ${{ matrix.runner }}
@@ -218,6 +219,8 @@ jobs:
           VITE_APP_VERSION: ${{ needs.release-preflight.outputs.app_version }}
           VITE_RELEASE_TAG: ${{ needs.release-preflight.outputs.release_tag }}
           VITE_GIT_SHA: ${{ needs.release-preflight.outputs.git_sha }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: apps/desktop
           args: ${{ matrix.tauriArgs }}
@@ -228,6 +231,7 @@ jobs:
           mkdir -p artifacts/release/desktop
           find target -type f ! -path '*/build/*' \( \
             -name '*.AppImage' -o \
+            -name '*.AppImage.sig' -o \
             -name '*.AppImage.tar.gz' -o \
             -name '*.AppImage.tar.gz.sig' -o \
             -name '*.deb' -o \
@@ -235,7 +239,9 @@ jobs:
             -name '*.dmg' -o \
             -name '*.app.tar.gz' -o \
             -name '*.app.tar.gz.sig' -o \
-            -name '*.exe' \
+            -name '*.exe' -o \
+            -name '*.exe.sig' -o \
+            -name 'latest.json' \
           \) -print -exec cp {} artifacts/release/desktop/ \;
           test -n "$(find artifacts/release/desktop -type f -print -quit)"
 
@@ -375,7 +381,7 @@ jobs:
           fi
 
           edit_flags=(--title "$RELEASE_TAG" --draft=false)
-          create_flags=(--title "$RELEASE_TAG" --notes "Automated unsigned release build for $RELEASE_TAG.")
+          create_flags=(--title "$RELEASE_TAG" --notes "Automated release build for $RELEASE_TAG.")
           if [[ "$IS_PRERELEASE" == "true" ]]; then
             edit_flags+=(--prerelease)
             create_flags+=(--prerelease --latest=false)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +970,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1346,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2381,6 +2411,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,6 +2688,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2952,6 +3018,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3040,6 +3118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,6 +3157,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3777,15 +3875,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3934,6 +4037,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3942,6 +4057,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3973,6 +4115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4350,6 +4501,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4591,7 +4752,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -4631,6 +4792,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4660,10 +4832,12 @@ dependencies = [
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-secure-storage",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-store",
+ "tauri-plugin-updater",
  "tauri-plugin-webdriver",
  "tauri-plugin-window-state",
  "tokio",
@@ -4710,7 +4884,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -5002,6 +5176,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-secure-storage"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5067,6 +5251,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-plugin-webdriver"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5124,7 +5341,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -5147,7 +5364,7 @@ checksum = "fe41e015bf8fc4d6477ff4926a0ef769dc64ff34c7b0038b6f7cacae892acb5c"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -6098,6 +6315,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6701,7 +6927,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -6773,6 +6999,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"
@@ -6952,6 +7188,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/apps/desktop/e2e/helpers/desktop.ts
+++ b/apps/desktop/e2e/helpers/desktop.ts
@@ -21,6 +21,13 @@ interface DesktopAutomation {
   reset(): void;
   clearRecordedCalls(): void;
   getRecordedCalls(): RecordedCall[];
+  setUpdateAvailable(update?: Partial<{
+    currentVersion: string;
+    version: string;
+    date: string | null;
+    body: string | null;
+  }> | null): void;
+  setUpdateError(message: string | null): void;
   setNextMutationFailure(operation: string, error: string): void;
   getPendingMutationFailure(): { operation: string; error: string } | null;
   syncCallCount(): number;

--- a/apps/desktop/e2e/updater.spec.ts
+++ b/apps/desktop/e2e/updater.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test';
+
+import { gotoDesktop, readRecordedCalls, waitForHomeReady } from './helpers/desktop';
+
+test.describe('desktop updater', () => {
+  test('startup update prompt appears once', async ({ page }) => {
+    await gotoDesktop(page, {
+      scenario: 'empty',
+      appScenario: 'connected',
+      searchParams: { mockUpdate: 'available' },
+    });
+    await waitForHomeReady(page);
+
+    await expect(page.getByText('Taurent v1.1.0 is available')).toHaveCount(1);
+
+    const calls = await readRecordedCalls(page);
+    expect(calls.filter((call) => call.name === 'checkForUpdate')).toHaveLength(1);
+  });
+
+  test('Later dismisses the startup prompt without installing', async ({ page }) => {
+    await gotoDesktop(page, {
+      scenario: 'empty',
+      appScenario: 'connected',
+      searchParams: { mockUpdate: 'available' },
+    });
+    await waitForHomeReady(page);
+
+    await page.getByRole('button', { name: 'Later', exact: true }).click();
+    await expect(page.getByText('Taurent v1.1.0 is available')).not.toBeVisible();
+
+    const calls = await readRecordedCalls(page);
+    expect(calls.some((call) => call.name === 'downloadAndInstallUpdate')).toBe(false);
+  });
+
+  test('manual check works from About settings', async ({ page }) => {
+    await gotoDesktop(page, {
+      path: '/settings-window?section=desktop-about',
+      scenario: 'empty',
+      appScenario: 'connected',
+    });
+    await expect(page.getByRole('heading', { name: 'About', exact: true })).toBeVisible();
+
+    await page.evaluate(() => {
+      window.__TAURENT_AUTOMATION__?.setUpdateAvailable({ version: '1.2.0' });
+      window.__TAURENT_AUTOMATION__?.clearRecordedCalls();
+    });
+
+    await page.getByRole('button', { name: 'Check for updates', exact: true }).click();
+    await expect(page.getByText('Taurent v1.2.0 is available.')).toBeVisible();
+
+    const calls = await readRecordedCalls(page);
+    expect(calls.map((call) => call.name)).toContain('checkForUpdate');
+  });
+
+  test('install flow shows progress and relaunch-ready state', async ({ page }) => {
+    await gotoDesktop(page, {
+      scenario: 'empty',
+      appScenario: 'connected',
+      searchParams: { mockUpdate: 'available' },
+    });
+    await waitForHomeReady(page);
+
+    await page.getByRole('button', { name: 'Update', exact: true }).click();
+    await expect(page.getByText('Update installed')).toBeVisible();
+    await expect(page.getByText('Relaunch Taurent to finish updating.')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Relaunch', exact: true }).click();
+
+    const callNames = (await readRecordedCalls(page)).map((call) => call.name);
+    expect(callNames).toContain('checkForUpdate');
+    expect(callNames).toContain('downloadAndInstallUpdate');
+    expect(callNames).toContain('relaunchApp');
+  });
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -57,6 +57,7 @@
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-store": "^2.4.3",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "@tauri-apps/plugin-window-state": "^2.4.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.21.0",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -39,6 +39,8 @@ qb-tauri = { path = "../../../crates/qb-tauri", features = ["desktop"] }
 urlencoding = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 tauri-plugin-webdriver = { version = "0.2.1", optional = true }
+tauri-plugin-updater = "2.10.1"
+tauri-plugin-process = "2.3.1"
 
 [features]
 webdriver = ["tauri-plugin-webdriver"]

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -52,6 +52,8 @@
     "secure-storage:allow-remove-item",
     "autostart:allow-enable",
     "autostart:allow-disable",
-    "autostart:allow-is-enabled"
+    "autostart:allow-is-enabled",
+    "updater:default",
+    "process:allow-restart"
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -624,6 +624,8 @@ pub fn run() {
         tauri_plugin_autostart::MacosLauncher::LaunchAgent,
         None,
     ));
+    let builder = builder.plugin(tauri_plugin_process::init());
+    let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
     builder
         .manage(create_session_state())
         .manage(PendingTorrentFiles::new())

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -33,6 +33,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/32x32.png",
@@ -55,6 +56,12 @@
     }
   },
   "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk3MDIxNUZCQjhGQUFDNzUKUldSMXJQcTQreFVDbDBoMmRacE5WckNucFVlSzZ2QmN4N3Mzc0pvWGlTUGtqRkNmK3h4Vld4aUoK",
+      "endpoints": [
+        "https://github.com/racos-dev/taurent/releases/latest/download/latest.json"
+      ]
+    },
     "window": {
       "all": true
     },

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -18,6 +18,7 @@ import { AuxWindowLayout } from './windows/layout/AuxWindowLayout';
 import { DialogWindowLayout } from './windows/layout/DialogWindowLayout';
 import { MainWindowLayout } from './windows/layout/MainWindowLayout';
 import { RootErrorBoundary } from './components/RootErrorBoundary';
+import { AppUpdateBanner } from './components/AppUpdateBanner';
 import { queryClient } from './queryClient';
 import { SearchFocusProvider } from './contexts/SearchFocusProvider';
 import { useFocusSearch } from './contexts/useSearchFocusHooks';
@@ -135,6 +136,7 @@ function DesktopMainWindowRoot() {
   return (
     <>
       <MainWindowOperationNotifications />
+      <AppUpdateBanner />
       <MainWindowLayout>
         <AuthBoundary />
       </MainWindowLayout>

--- a/apps/desktop/src/components/AppUpdateBanner.tsx
+++ b/apps/desktop/src/components/AppUpdateBanner.tsx
@@ -31,20 +31,15 @@ export function AppUpdateBanner() {
     if (startupCheckCompleted) return;
     startupCheckCompleted = true;
 
-    let cancelled = false;
     void BridgeAdapter.checkForUpdate()
       .then((update) => {
-        if (!cancelled && update) {
+        if (update) {
           setState({ status: 'available', update });
         }
       })
       .catch(() => {
         // Startup update checks stay quiet. Manual checks surface errors in About.
       });
-
-    return () => {
-      cancelled = true;
-    };
   }, []);
 
   const handleInstall = useCallback(async (update: AppUpdateInfo) => {

--- a/apps/desktop/src/components/AppUpdateBanner.tsx
+++ b/apps/desktop/src/components/AppUpdateBanner.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { BridgeAdapter } from '@taurent/bridge/adapters/desktop';
+import type { AppUpdateInfo, AppUpdateProgress } from '@taurent/bridge/contracts';
+import { Button, ProgressBar } from '@taurent/web-ui';
+
+const RELEASE_URL = 'https://github.com/racos-dev/taurent/releases/latest';
+
+type UpdateBannerState =
+  | { status: 'hidden' }
+  | { status: 'available'; update: AppUpdateInfo }
+  | { status: 'installing'; update: AppUpdateInfo; downloaded: number; contentLength: number | null }
+  | { status: 'installed'; update: AppUpdateInfo }
+  | { status: 'error'; update: AppUpdateInfo; message: string };
+
+let startupCheckCompleted = false;
+
+function progressRatio(downloaded: number, contentLength: number | null): number {
+  if (!contentLength || contentLength <= 0) return 0;
+  return Math.min(downloaded / contentLength, 1);
+}
+
+function isWindowsRuntime(): boolean {
+  return navigator.userAgent.includes('Windows');
+}
+
+export function AppUpdateBanner() {
+  const [state, setState] = useState<UpdateBannerState>({ status: 'hidden' });
+
+  useEffect(() => {
+    if (startupCheckCompleted) return;
+    startupCheckCompleted = true;
+
+    let cancelled = false;
+    void BridgeAdapter.checkForUpdate()
+      .then((update) => {
+        if (!cancelled && update) {
+          setState({ status: 'available', update });
+        }
+      })
+      .catch(() => {
+        // Startup update checks stay quiet. Manual checks surface errors in About.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleInstall = useCallback(async (update: AppUpdateInfo) => {
+    setState({ status: 'installing', update, downloaded: 0, contentLength: null });
+
+    try {
+      await BridgeAdapter.downloadAndInstallUpdate((event: AppUpdateProgress) => {
+        if (event.event === 'Started') {
+          setState({ status: 'installing', update, downloaded: 0, contentLength: event.contentLength });
+          return;
+        }
+        if (event.event === 'Progress') {
+          setState({
+            status: 'installing',
+            update,
+            downloaded: event.downloaded,
+            contentLength: event.contentLength,
+          });
+          return;
+        }
+        setState({ status: 'installing', update, downloaded: event.downloaded, contentLength: event.contentLength });
+      });
+      setState({ status: 'installed', update });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Update install failed.';
+      setState({ status: 'error', update, message });
+    }
+  }, []);
+
+  const handleRelease = useCallback(() => {
+    window.open(RELEASE_URL, '_blank', 'noopener,noreferrer');
+  }, []);
+
+  const copy = useMemo(() => {
+    if (state.status === 'hidden') return null;
+    if (state.status === 'installed') {
+      return {
+        title: 'Update installed',
+        body: 'Relaunch Taurent to finish updating.',
+      };
+    }
+    if (state.status === 'installing') {
+      return {
+        title: `Installing Taurent v${state.update.version}`,
+        body: state.contentLength ? 'Downloading update package.' : 'Downloading update package...',
+      };
+    }
+    if (state.status === 'error') {
+      return {
+        title: 'Update failed',
+        body: state.message,
+      };
+    }
+    return {
+      title: `Taurent v${state.update.version} is available`,
+      body: isWindowsRuntime()
+        ? 'Install when ready. On Windows, the app may close immediately during installation.'
+        : 'Install when ready, or view the release notes first.',
+    };
+  }, [state]);
+
+  if (state.status === 'hidden' || !copy) return null;
+
+  const progress = state.status === 'installing'
+    ? progressRatio(state.downloaded, state.contentLength)
+    : 0;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 w-[calc(100vw-2rem)] max-w-sm rounded-sm border border-border bg-surface p-3 shadow-lg">
+      <div className="space-y-3">
+        <div>
+          <h2 className="text-sm font-semibold text-text-primary">{copy.title}</h2>
+          <p className="mt-1 text-xs text-text-secondary">{copy.body}</p>
+        </div>
+
+        {state.status === 'installing' ? (
+          <ProgressBar progress={progress} size="sm" showLabel={state.contentLength !== null} />
+        ) : null}
+
+        <div className="flex flex-wrap justify-end gap-2">
+          {state.status === 'available' || state.status === 'error' ? (
+            <>
+              <Button variant="ghost" size="sm" onClick={handleRelease}>View release</Button>
+              <Button variant="secondary" size="sm" onClick={() => setState({ status: 'hidden' })}>Later</Button>
+              <Button variant="primary" size="sm" onClick={() => void handleInstall(state.update)}>Update</Button>
+            </>
+          ) : null}
+          {state.status === 'installed' ? (
+            <>
+              <Button variant="secondary" size="sm" onClick={() => setState({ status: 'hidden' })}>Later</Button>
+              <Button variant="primary" size="sm" onClick={() => void BridgeAdapter.relaunchApp()}>Relaunch</Button>
+            </>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/Settings/DesktopAboutSettings.tsx
+++ b/apps/desktop/src/components/Settings/DesktopAboutSettings.tsx
@@ -1,8 +1,86 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
+import { BridgeAdapter } from '@taurent/bridge/adapters/desktop';
+import type { AppUpdateInfo, AppUpdateProgress } from '@taurent/bridge/contracts';
+import { Button, ProgressBar } from '@taurent/web-ui';
 import { appBuildMetadata } from '../../buildMetadata';
 
+type UpdateSettingsState =
+  | { status: 'idle' }
+  | { status: 'checking' }
+  | { status: 'available'; update: AppUpdateInfo }
+  | { status: 'not-available' }
+  | { status: 'error'; message: string }
+  | { status: 'installing'; update: AppUpdateInfo; downloaded: number; contentLength: number | null }
+  | { status: 'installed'; update: AppUpdateInfo };
+
+const RELEASE_URL = 'https://github.com/racos-dev/taurent/releases/latest';
+
+function progressRatio(downloaded: number, contentLength: number | null): number {
+  if (!contentLength || contentLength <= 0) return 0;
+  return Math.min(downloaded / contentLength, 1);
+}
+
 export const DesktopAboutSettings = React.memo(() => {
+  const [updateState, setUpdateState] = useState<UpdateSettingsState>({ status: 'idle' });
+
+  const handleCheck = useCallback(async () => {
+    setUpdateState({ status: 'checking' });
+    try {
+      const update = await BridgeAdapter.checkForUpdate();
+      setUpdateState(update ? { status: 'available', update } : { status: 'not-available' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to check for updates.';
+      setUpdateState({ status: 'error', message });
+    }
+  }, []);
+
+  const handleInstall = useCallback(async (update: AppUpdateInfo) => {
+    setUpdateState({ status: 'installing', update, downloaded: 0, contentLength: null });
+    try {
+      await BridgeAdapter.downloadAndInstallUpdate((event: AppUpdateProgress) => {
+        if (event.event === 'Started') {
+          setUpdateState({ status: 'installing', update, downloaded: 0, contentLength: event.contentLength });
+          return;
+        }
+        if (event.event === 'Progress') {
+          setUpdateState({
+            status: 'installing',
+            update,
+            downloaded: event.downloaded,
+            contentLength: event.contentLength,
+          });
+          return;
+        }
+        setUpdateState({ status: 'installing', update, downloaded: event.downloaded, contentLength: event.contentLength });
+      });
+      setUpdateState({ status: 'installed', update });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to install update.';
+      setUpdateState({ status: 'error', message });
+    }
+  }, []);
+
+  const updateMessage = useMemo(() => {
+    switch (updateState.status) {
+      case 'checking':
+        return 'Checking for updates...';
+      case 'available':
+        return `Taurent v${updateState.update.version} is available.`;
+      case 'not-available':
+        return 'Taurent is up to date.';
+      case 'error':
+        return updateState.message;
+      case 'installing':
+        return updateState.contentLength ? 'Downloading update package.' : 'Downloading update package...';
+      case 'installed':
+        return 'Update installed. Relaunch Taurent to finish.';
+      case 'idle':
+      default:
+        return 'Stable GitHub releases only.';
+    }
+  }, [updateState]);
+
   return (
     <div className="rounded-sm border border-border bg-surface p-3">
       <div className="flex flex-col items-center text-center">
@@ -28,6 +106,54 @@ export const DesktopAboutSettings = React.memo(() => {
         >
           View on GitHub
         </a>
+      </div>
+      <div className="mt-4 border-t border-border pt-3">
+        <div className="flex flex-col gap-3">
+          <div className="text-center">
+            <h3 className="text-xs font-semibold text-text-primary">Updates</h3>
+            <p className="mt-1 text-xs text-text-secondary">{updateMessage}</p>
+            {updateState.status === 'installing' ? (
+              <ProgressBar
+                className="mt-3"
+                progress={progressRatio(updateState.downloaded, updateState.contentLength)}
+                size="sm"
+                showLabel={updateState.contentLength !== null}
+              />
+            ) : null}
+          </div>
+          <div className="flex flex-wrap justify-center gap-2">
+            {updateState.status === 'available' ? (
+              <>
+                <a
+                  href={RELEASE_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex h-9 items-center rounded-sm px-3 text-xs font-medium text-primary hover:underline"
+                >
+                  View release
+                </a>
+                <Button variant="primary" size="sm" onClick={() => void handleInstall(updateState.update)}>
+                  Update
+                </Button>
+              </>
+            ) : null}
+            {updateState.status === 'installed' ? (
+              <Button variant="primary" size="sm" onClick={() => void BridgeAdapter.relaunchApp()}>
+                Relaunch
+              </Button>
+            ) : (
+              <Button
+                variant="secondary"
+                size="sm"
+                loading={updateState.status === 'checking'}
+                disabled={updateState.status === 'installing'}
+                onClick={() => void handleCheck()}
+              >
+                Check for updates
+              </Button>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/testing/mockDesktopBridge.test.ts
+++ b/apps/desktop/src/testing/mockDesktopBridge.test.ts
@@ -12,6 +12,7 @@
 //     re-emission on maindata state changes.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppUpdateInfo } from '@taurent/bridge/contracts';
 import type {
   MaindataSyncChangedEvent,
   RustCapabilitiesResponse,
@@ -27,6 +28,8 @@ interface AutomationControl {
   reset: () => void;
   clearRecordedCalls: () => void;
   getRecordedCalls: () => Array<{ name: string; args: unknown[] }>;
+  setUpdateAvailable: (update?: Partial<AppUpdateInfo> | null) => void;
+  setUpdateError: (message: string | null) => void;
 }
 
 interface AutomationWindow {
@@ -135,6 +138,47 @@ describe('mockDesktopBridge', () => {
       unsubscribe();
       automation.emitMaindataSyncChanged(makeEvent(1));
       expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updater mock', () => {
+    it('returns null when no update is configured', async () => {
+      await expect(bridge.checkForUpdate()).resolves.toBeNull();
+      expect(automation.getRecordedCalls().map((call) => call.name)).toContain('checkForUpdate');
+    });
+
+    it('returns configured update info and emits install progress', async () => {
+      automation.setUpdateAvailable({ version: '2.0.0' });
+
+      await expect(bridge.checkForUpdate()).resolves.toMatchObject({ version: '2.0.0' });
+
+      const progress = vi.fn();
+      await bridge.downloadAndInstallUpdate(progress);
+
+      expect(progress.mock.calls.map((call) => call[0].event)).toEqual([
+        'Started',
+        'Progress',
+        'Progress',
+        'Finished',
+      ]);
+      expect(automation.getRecordedCalls().map((call) => call.name)).toEqual([
+        'checkForUpdate',
+        'downloadAndInstallUpdate',
+      ]);
+    });
+
+    it('surfaces update check failures and records relaunch calls', async () => {
+      automation.setUpdateError('updater unavailable');
+
+      await expect(bridge.checkForUpdate()).rejects.toThrow('updater unavailable');
+
+      automation.setUpdateError(null);
+      await bridge.relaunchApp();
+
+      expect(automation.getRecordedCalls().map((call) => call.name)).toEqual([
+        'checkForUpdate',
+        'relaunchApp',
+      ]);
     });
   });
 

--- a/apps/desktop/src/testing/mockDesktopBridge.ts
+++ b/apps/desktop/src/testing/mockDesktopBridge.ts
@@ -7,7 +7,12 @@
 //
 // Delta injection via window.__TAURENT_AUTOMATION__.injectDelta().
 
-import type { DesktopBridge, ResolveResult } from '@taurent/bridge/contracts/interfaces';
+import type {
+  AppUpdateInfo,
+  AppUpdateProgress,
+  DesktopBridge,
+  ResolveResult,
+} from '@taurent/bridge/contracts/interfaces';
 import type {
   AddServerInput,
   AddTorrentOptions,
@@ -44,6 +49,7 @@ const APP_SCENARIOS = [
   'saved-server-credential-unavailable',
 ] as const;
 type AppScenario = (typeof APP_SCENARIOS)[number];
+type UpdateScenario = 'none' | 'available' | 'error';
 
 interface RecordedCall {
   name: string;
@@ -53,6 +59,35 @@ interface RecordedCall {
 interface MutationFailureConfig {
   operation: string;
   error: string;
+}
+
+const DEFAULT_UPDATE: AppUpdateInfo = {
+  currentVersion: '1.0.0',
+  version: '1.1.0',
+  date: '2026-07-01T00:00:00.000Z',
+  body: 'Mock update release notes.',
+};
+
+function isUpdateScenario(value: string): value is UpdateScenario {
+  return value === 'none' || value === 'available' || value === 'error';
+}
+
+function getUpdateScenario(): UpdateScenario {
+  if (typeof window === 'undefined') return 'none';
+  try {
+    const urlParams = new URLSearchParams(window.location.search);
+    const urlScenario = urlParams.get('mockUpdate');
+    if (urlScenario && isUpdateScenario(urlScenario)) {
+      return urlScenario;
+    }
+    const stored = window.localStorage.getItem('taurent:mock-update');
+    if (stored && isUpdateScenario(stored)) {
+      return stored;
+    }
+  } catch {
+    // ignore
+  }
+  return 'none';
 }
 
 const DEFAULT_SERVER: SavedServerSummary = {
@@ -295,6 +330,8 @@ let _serverTestResult: TestConnectionResult = { success: true };
 let _healthCheckResult = true;
 let _recordedCalls: RecordedCall[] = [];
 let _nextMutationFailure: MutationFailureConfig | null = null;
+let _availableUpdate: AppUpdateInfo | null = getUpdateScenario() === 'available' ? { ...DEFAULT_UPDATE } : null;
+let _updateError: string | null = getUpdateScenario() === 'error' ? 'Mock update check failed.' : null;
 
 // Maindata sync listeners for qBClient.addMaindataSyncListener
 const _maindataSyncListeners = new Set<(event: MaindataSyncChangedEvent) => void>();
@@ -407,6 +444,8 @@ interface AutomationControl {
   syncCallCount: () => number;
   getRecordedCalls: () => RecordedCall[];
   clearRecordedCalls: () => void;
+  setUpdateAvailable: (update?: Partial<AppUpdateInfo> | null) => void;
+  setUpdateError: (message: string | null) => void;
   setNextMutationFailure: (operation: string, error: string) => void;
   getPendingMutationFailure: () => { operation: string; error: string } | null;
   clearMutationFaults: () => void;
@@ -540,6 +579,13 @@ const _ctrl: AutomationControl = {
   clearRecordedCalls: () => {
     _recordedCalls = [];
   },
+  setUpdateAvailable: (update: Partial<AppUpdateInfo> | null = DEFAULT_UPDATE) => {
+    _availableUpdate = update ? { ...DEFAULT_UPDATE, ...update } : null;
+    _updateError = null;
+  },
+  setUpdateError: (message: string | null) => {
+    _updateError = message;
+  },
   setNextMutationFailure: (operation: string, error: string) => {
     _nextMutationFailure = { operation, error };
   },
@@ -615,6 +661,8 @@ const _ctrl: AutomationControl = {
     _pendingDelta = null;
     _recordedCalls = [];
     _nextMutationFailure = null;
+    _availableUpdate = null;
+    _updateError = null;
     _syncDelayMs = 0;
     _syncErrorRemaining = 0;
     _syncMalformedRemaining = 0;
@@ -1613,6 +1661,30 @@ function createMockBridge(): DesktopBridge {
     },
     async revealLocalItem(_path: string): Promise<void> {
       return;
+    },
+    async checkForUpdate(): Promise<AppUpdateInfo | null> {
+      recordCall('checkForUpdate', []);
+      if (_updateError) {
+        throw new Error(_updateError);
+      }
+      return _availableUpdate ? { ..._availableUpdate } : null;
+    },
+    async downloadAndInstallUpdate(onProgress?: (event: AppUpdateProgress) => void): Promise<void> {
+      recordCall('downloadAndInstallUpdate', []);
+      if (_updateError) {
+        throw new Error(_updateError);
+      }
+      if (!_availableUpdate) {
+        throw new Error('No update is available.');
+      }
+
+      onProgress?.({ event: 'Started', contentLength: 100 });
+      onProgress?.({ event: 'Progress', chunkLength: 40, downloaded: 40, contentLength: 100 });
+      onProgress?.({ event: 'Progress', chunkLength: 60, downloaded: 100, contentLength: 100 });
+      onProgress?.({ event: 'Finished', downloaded: 100, contentLength: 100 });
+    },
+    async relaunchApp(): Promise<void> {
+      recordCall('relaunchApp', []);
     },
 
     syncMenuState(state: import('@taurent/bridge/contracts/interfaces').NativeMenuState) {

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -24,6 +24,7 @@
     "./adapters": "./src/adapters/index.ts",
     "./adapters/desktop": "./src/adapters/desktop.ts",
     "./desktop/notification": "./src/desktop/notification.ts",
+    "./desktop/updater": "./src/desktop/updater.ts",
     "./adapters/mobile-tauri": "./src/adapters/mobile-tauri.ts",
     "./platform": "./src/platform.ts",
     "./web": "./src/web.ts",
@@ -39,7 +40,9 @@
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-log": "^2.8.0",
     "@tauri-apps/plugin-notification": "^2.3.3",
-    "@tauri-apps/plugin-shell": "^2.3.5"
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-shell": "^2.3.5",
+    "@tauri-apps/plugin-updater": "^2.10.1"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",

--- a/packages/bridge/src/adapters/desktop.ts
+++ b/packages/bridge/src/adapters/desktop.ts
@@ -1,8 +1,21 @@
 // Desktop bridge adapter
 import { createTauriTransport } from '../transport/tauriTransport';
 import type { Transport } from '../transport/transport';
-import type { DesktopBridge, NativeMenuState, NativeUiAction, ResolveResult } from '../contracts/interfaces';
-export type { NativeMenuState, NativeUiAction, ResolveResult } from '../contracts/interfaces';
+import type {
+  AppUpdateInfo,
+  AppUpdateProgress,
+  DesktopBridge,
+  NativeMenuState,
+  NativeUiAction,
+  ResolveResult,
+} from '../contracts/interfaces';
+export type {
+  AppUpdateInfo,
+  AppUpdateProgress,
+  NativeMenuState,
+  NativeUiAction,
+  ResolveResult,
+} from '../contracts/interfaces';
 import type {
   SessionSnapshot,
   SessionStatus,
@@ -525,6 +538,21 @@ export function createDesktopBridge(transport?: Transport): DesktopBridge {
 
     async sessionHealthCheck(): Promise<boolean> {
       return session.sessionHealthCheck();
+    },
+
+    async checkForUpdate(): Promise<AppUpdateInfo | null> {
+      const updater = await import('../desktop/updater');
+      return updater.checkForUpdate();
+    },
+
+    async downloadAndInstallUpdate(onProgress?: (event: AppUpdateProgress) => void): Promise<void> {
+      const updater = await import('../desktop/updater');
+      return updater.downloadAndInstallUpdate(onProgress);
+    },
+
+    async relaunchApp(): Promise<void> {
+      const updater = await import('../desktop/updater');
+      return updater.relaunchApp();
     },
 
     async sessionSwitchServer(

--- a/packages/bridge/src/contracts/interfaces.ts
+++ b/packages/bridge/src/contracts/interfaces.ts
@@ -5,6 +5,18 @@ export type ResolveResult =
   | { kind: 'resolved'; localPath: string }
   | { kind: 'unmapped'; serverPath: string };
 
+export interface AppUpdateInfo {
+  currentVersion: string;
+  version: string;
+  date: string | null;
+  body: string | null;
+}
+
+export type AppUpdateProgress =
+  | { event: 'Started'; contentLength: number | null }
+  | { event: 'Progress'; chunkLength: number; downloaded: number; contentLength: number | null }
+  | { event: 'Finished'; downloaded: number; contentLength: number | null };
+
 import { BridgeCapabilities } from './capabilities';
 
 import type {
@@ -366,6 +378,12 @@ export interface DesktopBridge extends SessionLifecycleBridge {
   openLocalPath(path: string): Promise<void>;
   /** Reveal a local item in the native file explorer (Rust). Falls back to opening the containing directory on Linux. */
   revealLocalItem(path: string): Promise<void>;
+  /** Check the configured updater endpoint for a stable desktop app update. */
+  checkForUpdate(): Promise<AppUpdateInfo | null>;
+  /** Download and install the previously checked update, reporting download progress when available. */
+  downloadAndInstallUpdate(onProgress?: (event: AppUpdateProgress) => void): Promise<void>;
+  /** Relaunch the app after an installed update is ready. */
+  relaunchApp(): Promise<void>;
 }
 
 /// Dynamic menu state synced from the frontend to the native macOS app menu.

--- a/packages/bridge/src/desktop/updater.test.ts
+++ b/packages/bridge/src/desktop/updater.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  check: vi.fn(),
+  relaunch: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-updater', () => ({
+  check: mocks.check,
+}));
+
+vi.mock('@tauri-apps/plugin-process', () => ({
+  relaunch: mocks.relaunch,
+}));
+
+function makeUpdate(version = '1.1.0') {
+  return {
+    currentVersion: '1.0.0',
+    version,
+    date: '2026-07-01T00:00:00.000Z',
+    body: 'Release notes',
+    close: vi.fn().mockResolvedValue(undefined),
+    downloadAndInstall: vi.fn(async (onProgress: (event: unknown) => void) => {
+      onProgress({ event: 'Started', data: { contentLength: 100 } });
+      onProgress({ event: 'Progress', data: { chunkLength: 25 } });
+      onProgress({ event: 'Finished' });
+    }),
+  };
+}
+
+describe('desktop updater bridge', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.check.mockReset();
+    mocks.relaunch.mockReset();
+  });
+
+  it('maps a native update into bridge update info', async () => {
+    const update = makeUpdate();
+    mocks.check.mockResolvedValue(update);
+    const updater = await import('./updater');
+
+    await expect(updater.checkForUpdate()).resolves.toEqual({
+      currentVersion: '1.0.0',
+      version: '1.1.0',
+      date: '2026-07-01T00:00:00.000Z',
+      body: 'Release notes',
+    });
+  });
+
+  it('returns null when no update is available', async () => {
+    mocks.check.mockResolvedValue(null);
+    const updater = await import('./updater');
+
+    await expect(updater.checkForUpdate()).resolves.toBeNull();
+  });
+
+  it('installs the checked update and reports normalized progress', async () => {
+    const update = makeUpdate('1.2.0');
+    mocks.check.mockResolvedValue(update);
+    const updater = await import('./updater');
+
+    await updater.checkForUpdate();
+    const progress = vi.fn();
+    await updater.downloadAndInstallUpdate(progress);
+
+    expect(update.downloadAndInstall).toHaveBeenCalledTimes(1);
+    expect(progress.mock.calls.map((call) => call[0])).toEqual([
+      { event: 'Started', contentLength: 100 },
+      { event: 'Progress', chunkLength: 25, downloaded: 25, contentLength: 100 },
+      { event: 'Finished', downloaded: 25, contentLength: 100 },
+    ]);
+  });
+
+  it('relaunches through the process plugin', async () => {
+    mocks.relaunch.mockResolvedValue(undefined);
+    const updater = await import('./updater');
+
+    await updater.relaunchApp();
+
+    expect(mocks.relaunch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/bridge/src/desktop/updater.ts
+++ b/packages/bridge/src/desktop/updater.ts
@@ -1,0 +1,69 @@
+import { check, type DownloadEvent, type Update } from '@tauri-apps/plugin-updater';
+import { relaunch } from '@tauri-apps/plugin-process';
+
+import type { AppUpdateInfo, AppUpdateProgress } from '../contracts/interfaces';
+
+let pendingUpdate: Update | null = null;
+
+function toUpdateInfo(update: Update): AppUpdateInfo {
+  return {
+    currentVersion: update.currentVersion,
+    version: update.version,
+    date: update.date ?? null,
+    body: update.body ?? null,
+  };
+}
+
+export async function checkForUpdate(): Promise<AppUpdateInfo | null> {
+  if (pendingUpdate) {
+    await pendingUpdate.close().catch(() => undefined);
+    pendingUpdate = null;
+  }
+
+  const update = await check();
+  pendingUpdate = update;
+  return update ? toUpdateInfo(update) : null;
+}
+
+export async function downloadAndInstallUpdate(
+  onProgress?: (event: AppUpdateProgress) => void,
+): Promise<void> {
+  const update = pendingUpdate ?? await check();
+  if (!update) {
+    throw new Error('No update is available.');
+  }
+
+  pendingUpdate = update;
+  let downloaded = 0;
+  let contentLength: number | null = null;
+
+  try {
+    await update.downloadAndInstall((event: DownloadEvent) => {
+      switch (event.event) {
+        case 'Started':
+          downloaded = 0;
+          contentLength = event.data.contentLength ?? null;
+          onProgress?.({ event: 'Started', contentLength });
+          break;
+        case 'Progress':
+          downloaded += event.data.chunkLength;
+          onProgress?.({
+            event: 'Progress',
+            chunkLength: event.data.chunkLength,
+            downloaded,
+            contentLength,
+          });
+          break;
+        case 'Finished':
+          onProgress?.({ event: 'Finished', downloaded, contentLength });
+          break;
+      }
+    });
+  } finally {
+    pendingUpdate = null;
+  }
+}
+
+export async function relaunchApp(): Promise<void> {
+  await relaunch();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@tauri-apps/plugin-store':
         specifier: ^2.4.3
         version: 2.4.3
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.10.1
+        version: 2.10.1
       '@tauri-apps/plugin-window-state':
         specifier: ^2.4.1
         version: 2.4.1
@@ -328,9 +331,15 @@ importers:
       '@tauri-apps/plugin-notification':
         specifier: ^2.3.3
         version: 2.3.3
+      '@tauri-apps/plugin-process':
+        specifier: ^2.3.1
+        version: 2.3.1
       '@tauri-apps/plugin-shell':
         specifier: ^2.3.5
         version: 2.3.5
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.10.1
+        version: 2.10.1
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -1254,11 +1263,17 @@ packages:
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
 
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
   '@tauri-apps/plugin-shell@2.3.5':
     resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
 
   '@tauri-apps/plugin-store@2.4.3':
     resolution: {integrity: sha512-9LWPj9yMphRi9czEtUv87XHbl1b6xgd9EXpPrUnq6nG7+nbtoF84d4Kwz9xhAv/Hf30sr58pq7EOlyI936y8qw==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@tauri-apps/plugin-window-state@2.4.1':
     resolution: {integrity: sha512-OuvdrzyY8Q5Dbzpj+GcrnV1iCeoZbcFdzMjanZMMcAEUNy/6PH5pxZPXpaZLOR7whlzXiuzx0L9EKZbH7zpdRw==}
@@ -4325,6 +4340,10 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.0
 
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
   '@tauri-apps/plugin-shell@2.3.5':
     dependencies:
       '@tauri-apps/api': 2.11.0
@@ -4332,6 +4351,10 @@ snapshots:
   '@tauri-apps/plugin-store@2.4.3':
     dependencies:
       '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-window-state@2.4.1':
     dependencies:

--- a/scripts/release/prepare-release-assets.mjs
+++ b/scripts/release/prepare-release-assets.mjs
@@ -1,4 +1,4 @@
-import { copyFileSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { copyFileSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, relative, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -6,9 +6,15 @@ const RELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.
 
 const REQUIRED_SUFFIXES = new Set([
   'macos-arm64.dmg',
+  'macos-arm64.app.tar.gz',
+  'macos-arm64.app.tar.gz.sig',
   'macos-x64.dmg',
+  'macos-x64.app.tar.gz',
+  'macos-x64.app.tar.gz.sig',
   'windows-x64-setup.exe',
+  'windows-x64-setup.exe.sig',
   'linux-x64.AppImage',
+  'linux-x64.AppImage.sig',
   'linux-x64.deb',
   'linux-x64.rpm',
   'android-universal-unsigned.apk',
@@ -40,21 +46,57 @@ function classifyAsset(sourceDir, file, releaseTag) {
   const fileName = basename(file);
   const lowerName = fileName.toLowerCase();
 
-  if (artifact === 'taurent-macos-apple-silicon' && lowerName.endsWith('.dmg')) {
-    return `Taurent-${releaseTag}-macos-arm64.dmg`;
+  if (artifact === 'taurent-macos-apple-silicon') {
+    if (lowerName.endsWith('.dmg')) {
+      return `Taurent-${releaseTag}-macos-arm64.dmg`;
+    }
+
+    if (lowerName.endsWith('.app.tar.gz.sig')) {
+      return `Taurent-${releaseTag}-macos-arm64.app.tar.gz.sig`;
+    }
+
+    if (lowerName.endsWith('.app.tar.gz')) {
+      return `Taurent-${releaseTag}-macos-arm64.app.tar.gz`;
+    }
   }
 
-  if (artifact === 'taurent-macos-intel' && lowerName.endsWith('.dmg')) {
-    return `Taurent-${releaseTag}-macos-x64.dmg`;
+  if (artifact === 'taurent-macos-intel') {
+    if (lowerName.endsWith('.dmg')) {
+      return `Taurent-${releaseTag}-macos-x64.dmg`;
+    }
+
+    if (lowerName.endsWith('.app.tar.gz.sig')) {
+      return `Taurent-${releaseTag}-macos-x64.app.tar.gz.sig`;
+    }
+
+    if (lowerName.endsWith('.app.tar.gz')) {
+      return `Taurent-${releaseTag}-macos-x64.app.tar.gz`;
+    }
   }
 
   if (artifact === 'taurent-windows' && lowerName.endsWith('.exe') && lowerName.includes('setup')) {
     return `Taurent-${releaseTag}-windows-x64-setup.exe`;
   }
 
+  if (artifact === 'taurent-windows' && lowerName.endsWith('.exe.sig') && lowerName.includes('setup')) {
+    return `Taurent-${releaseTag}-windows-x64-setup.exe.sig`;
+  }
+
   if (artifact === 'taurent-linux') {
     if (fileName.endsWith('.AppImage')) {
       return `Taurent-${releaseTag}-linux-x64.AppImage`;
+    }
+
+    if (fileName.endsWith('.AppImage.sig')) {
+      return `Taurent-${releaseTag}-linux-x64.AppImage.sig`;
+    }
+
+    if (fileName.endsWith('.AppImage.tar.gz.sig')) {
+      return `Taurent-${releaseTag}-linux-x64.AppImage.tar.gz.sig`;
+    }
+
+    if (fileName.endsWith('.AppImage.tar.gz')) {
+      return `Taurent-${releaseTag}-linux-x64.AppImage.tar.gz`;
     }
 
     if (lowerName.endsWith('.deb')) {
@@ -71,6 +113,42 @@ function classifyAsset(sourceDir, file, releaseTag) {
   }
 
   return '';
+}
+
+function updaterPlatform({ targetName, signatureName }) {
+  return {
+    signature: readFileSync(signatureName, 'utf8').trim(),
+    url: `https://github.com/racos-dev/taurent/releases/download/${targetName.releaseTag}/${targetName.asset}`,
+  };
+}
+
+function buildUpdaterManifest(selected, releaseTag) {
+  const signaturePath = (suffix) => selected.get(`Taurent-${releaseTag}-${suffix}.sig`);
+  const target = (asset) => ({ releaseTag, asset: `Taurent-${releaseTag}-${asset}` });
+
+  return {
+    version: releaseTag.slice(1),
+    pub_date: new Date().toISOString(),
+    platforms: {
+      'darwin-aarch64': updaterPlatform({
+        targetName: target('macos-arm64.app.tar.gz'),
+        signatureName: signaturePath('macos-arm64.app.tar.gz'),
+      }),
+      'darwin-x86_64': updaterPlatform({
+        targetName: target('macos-x64.app.tar.gz'),
+        signatureName: signaturePath('macos-x64.app.tar.gz'),
+      }),
+      'linux-x86_64': updaterPlatform({
+        targetName: target('linux-x64.AppImage'),
+        signatureName: signaturePath('linux-x64.AppImage'),
+      }),
+      'windows-x86_64': updaterPlatform({
+        targetName: target('windows-x64-setup.exe'),
+        signatureName: signaturePath('windows-x64-setup.exe'),
+      }),
+    },
+    notes: `Taurent ${releaseTag.slice(1)} release.`,
+  };
 }
 
 export function prepareReleaseAssets({
@@ -128,6 +206,11 @@ export function prepareReleaseAssets({
     copyFileSync(source, target);
     copied.push(targetName);
   }
+
+  const latestJson = buildUpdaterManifest(selected, releaseTag);
+  writeFileSync(join(outputDir, 'latest.json'), `${JSON.stringify(latestJson, null, 2)}\n`);
+  copied.push('latest.json');
+  copied.sort((a, b) => a.localeCompare(b));
 
   return { copied, skipped };
 }

--- a/scripts/release/prepare-release-assets.test.mjs
+++ b/scripts/release/prepare-release-assets.test.mjs
@@ -25,10 +25,14 @@ const completeAssetSet = [
   'taurent-macos-apple-silicon/Taurent.app.tar.gz',
   'taurent-macos-apple-silicon/Taurent.app.tar.gz.sig',
   'taurent-macos-intel/Taurent_1.0.0_x64.dmg',
+  'taurent-macos-intel/Taurent.app.tar.gz',
+  'taurent-macos-intel/Taurent.app.tar.gz.sig',
   'taurent-windows/Taurent_1.0.0_x64-setup.exe',
+  'taurent-windows/Taurent_1.0.0_x64-setup.exe.sig',
   'taurent-windows/taurent.exe',
   'taurent-windows/Taurent_1.0.0_x64_en-US.msi',
   'taurent-linux/Taurent_1.0.0_amd64.AppImage',
+  'taurent-linux/Taurent_1.0.0_amd64.AppImage.sig',
   'taurent-linux/Taurent_1.0.0_amd64.AppImage.tar.gz',
   'taurent-linux/Taurent_1.0.0_amd64.AppImage.tar.gz.sig',
   'taurent-linux/Taurent_1.0.0_amd64.deb',
@@ -44,18 +48,37 @@ test('copies only public assets with tag-prefixed names', () => {
   });
 
   assert.deepEqual(result.copied, [
+    'latest.json',
     'Taurent-v0.9.0-beta.3-android-universal-unsigned.apk',
     'Taurent-v0.9.0-beta.3-linux-x64.AppImage',
+    'Taurent-v0.9.0-beta.3-linux-x64.AppImage.sig',
+    'Taurent-v0.9.0-beta.3-linux-x64.AppImage.tar.gz',
+    'Taurent-v0.9.0-beta.3-linux-x64.AppImage.tar.gz.sig',
     'Taurent-v0.9.0-beta.3-linux-x64.deb',
     'Taurent-v0.9.0-beta.3-linux-x64.rpm',
+    'Taurent-v0.9.0-beta.3-macos-arm64.app.tar.gz',
+    'Taurent-v0.9.0-beta.3-macos-arm64.app.tar.gz.sig',
     'Taurent-v0.9.0-beta.3-macos-arm64.dmg',
+    'Taurent-v0.9.0-beta.3-macos-x64.app.tar.gz',
+    'Taurent-v0.9.0-beta.3-macos-x64.app.tar.gz.sig',
     'Taurent-v0.9.0-beta.3-macos-x64.dmg',
     'Taurent-v0.9.0-beta.3-windows-x64-setup.exe',
+    'Taurent-v0.9.0-beta.3-windows-x64-setup.exe.sig',
   ]);
 
   assert.equal(
     readFileSync(join(fixture.outputDir, 'Taurent-v0.9.0-beta.3-android-universal-unsigned.apk'), 'utf8'),
     'taurent-android-unsigned-release-apk/app-universal-release-unsigned.apk',
+  );
+  const latestJson = JSON.parse(readFileSync(join(fixture.outputDir, 'latest.json'), 'utf8'));
+  assert.equal(latestJson.version, '0.9.0-beta.3');
+  assert.equal(
+    latestJson.platforms['darwin-aarch64'].url,
+    'https://github.com/racos-dev/taurent/releases/download/v0.9.0-beta.3/Taurent-v0.9.0-beta.3-macos-arm64.app.tar.gz',
+  );
+  assert.equal(
+    latestJson.platforms['windows-x86_64'].signature,
+    'taurent-windows/Taurent_1.0.0_x64-setup.exe.sig',
   );
   assert.ok(result.skipped.includes('taurent-windows/taurent.exe'));
   assert.ok(result.skipped.includes('taurent-windows/Taurent_1.0.0_x64_en-US.msi'));
@@ -79,6 +102,15 @@ test('fails when a required public asset is missing', () => {
   assert.throws(
     () => prepareReleaseAssets({ ...fixture, releaseTag: 'v0.9.0-beta.3' }),
     /Missing required release assets:/,
+  );
+});
+
+test('fails when required updater signatures are missing', () => {
+  const fixture = createFixture(completeAssetSet.filter((file) => !file.endsWith('.sig')));
+
+  assert.throws(
+    () => prepareReleaseAssets({ ...fixture, releaseTag: 'v0.9.0-beta.3' }),
+    /Taurent-v0\.9\.0-beta\.3-macos-arm64\.app\.tar\.gz\.sig/,
   );
 });
 


### PR DESCRIPTION
- Add tauri-plugin-updater and tauri-plugin-process Rust dependencies
- Wire updater plugin in lib.rs with configured pubkey and GitHub endpoints
- Configure tauri.conf.json with createUpdaterArtifacts and updater endpoints
- Bridge layer: add AppUpdateInfo/AppUpdateProgress contracts and updater.ts wrapping @tauri-apps/plugin-updater APIs (check, downloadAndInstall, relaunch)
- DesktopAboutSettings: add manual check-for-updates UI with progress bar
- AppUpdateBanner: toast-style notification on startup when update is available
- Mock bridge: add setUpdateAvailable/setUpdateError automation controls
- Unit tests for updater bridge, mock bridge updater flow, and E2E tests
- Release pipeline: sign artifacts via TAURI_SIGNING_PRIVATE_KEY env vars, collect .sig files and latest.json, generate updater manifest in prepare-release-assets.mjs
- Drop Rust from CodeQL (unused analysis target)