### PR TITLE
feat: add magnet deep-link support for desktop and mobile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4655,6 +4655,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-http",
  "tauri-plugin-log",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -50,6 +50,7 @@
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+    "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-http": "^2.5.9",
     "@tauri-apps/plugin-log": "^2.8.0",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tauri-plugin-store = "2.4.3"
 tauri-plugin-http = { version = "2.5.9", features = ["unsafe-headers"] }
 tauri-plugin-clipboard-manager = "2.3.2"
 tauri-plugin-notification = "2.3.3"
+tauri-plugin-deep-link = "2.4.9"
 tauri-plugin-dialog = "2.7.1"
 tauri-plugin-shell = "2.3.5"
 tauri-plugin-opener = "2.5.4"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use tauri::webview::PageLoadEvent;
 use tauri::{AppHandle, Emitter, Listener, Manager};
+use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_store::StoreExt;
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 
@@ -604,6 +605,38 @@ impl TorrentsFileOpen {
     }
 }
 
+// ─── Magnet link open handler ─────────────────────────────────────────────────
+
+struct MagnetLinkOpen;
+
+impl MagnetLinkOpen {
+    /// Enqueue magnet URLs, focus main window, and emit `magnet-link-open` event
+    /// with the genuinely new URLs that were not previously seen this session.
+    fn handle_urls(app: &tauri::AppHandle, raw_urls: Vec<String>, emit: bool) {
+        let magnet_urls: Vec<String> = raw_urls
+            .into_iter()
+            .filter(|url| url.starts_with("magnet:?"))
+            .collect();
+
+        if magnet_urls.is_empty() {
+            return;
+        }
+
+        let pending = app.state::<PendingMagnetLinks>();
+        let new_urls = pending.enqueue(magnet_urls);
+
+        if new_urls.is_empty() {
+            return;
+        }
+
+        show_main_window(app);
+
+        if emit {
+            let _ = app.emit("magnet-link-open", new_urls);
+        }
+    }
+}
+
 mod commands;
 
 use commands::{categories, menu, preferences, servers, tags, torrents, transfer};
@@ -611,6 +644,7 @@ use download_completion_notifications::{
     get_download_completion_notifications_enabled, set_download_completion_notifications_enabled,
 };
 use qb_tauri::app_builder::{add_desktop_plugins, add_shared_plugins, DESKTOP_SERVER_STORE_FILE};
+use qb_tauri::magnet_links::PendingMagnetLinks;
 use qb_tauri::server_repo::init_and_manage_repository;
 use qb_tauri::session::create_session_state;
 use qb_tauri::sync::{create_sync_manager_registry, setup_sync_lifecycle};
@@ -627,6 +661,7 @@ pub fn run() {
     builder
         .manage(create_session_state())
         .manage(PendingTorrentFiles::new())
+        .manage(PendingMagnetLinks::new())
         .manage(PendingNativeUiActions::new())
         .manage(PendingViewActions::new())
         .manage(ViewListenersReady::new())
@@ -759,6 +794,7 @@ pub fn run() {
             menu::sync_menu_state,
             menu::exit_app,
             get_pending_torrent_files,
+            qb_tauri::magnet_links::get_pending_magnet_links,
             get_pending_native_ui_actions,
             get_pending_view_actions,
             set_view_listeners_ready,
@@ -884,6 +920,25 @@ pub fn run() {
             );
             app.handle().plugin(tauri_plugin_shell::init())?;
 
+            // Register deep-link handler for magnet URLs arriving while the app is running.
+            {
+                let handle = app.handle().clone();
+                let _ = app.deep_link().on_open_url(move |event| {
+                    let urls: Vec<String> = event.urls().iter().map(|u| u.to_string()).collect();
+                    MagnetLinkOpen::handle_urls(&handle, urls, true);
+                });
+            }
+
+            // Check if the app was started via a deep link (cold-start).
+            {
+                let handle = app.handle();
+                if let Ok(Some(urls)) = app.deep_link().get_current() {
+                    let url_strings: Vec<String> = urls.iter().map(|u| u.to_string()).collect();
+                    let pending = handle.state::<PendingMagnetLinks>();
+                    pending.enqueue(url_strings);
+                }
+            }
+
             // Register single-instance plugin to handle .torrent file opens from a second instance.
             // Queue + emit because renderer may not be listening yet (cold-start case).
             app.handle()
@@ -891,10 +946,11 @@ pub fn run() {
                     let cwd = Path::new(&cwd);
                     TorrentsFileOpen::handle_raw_paths(
                         app,
-                        args,
+                        args.clone(),
                         Some(cwd),
                         true, // emit
                     );
+                    MagnetLinkOpen::handle_urls(app, args, true);
                 }))?;
 
             // Handle RunEvent::Opened on macOS when the app is already running and receives

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -58,6 +58,11 @@
     "window": {
       "all": true
     },
-    "opener": {}
+    "opener": {},
+    "deep-link": {
+      "desktop": {
+        "schemes": ["magnet"]
+      }
+    }
   }
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -11,6 +11,7 @@ import { FiltersScreen } from './screens/FiltersScreen';
 import { DialogHostScreen } from './screens/DialogHostScreen';
 import { useKeyboardShortcuts } from './hooks/shell/useKeyboardShortcuts';
 import { useTorrentFileOpen } from './hooks/shell/useTorrentFileOpen';
+import { useMagnetLinkOpen } from './hooks/shell/useMagnetLinkOpen';
 import { useDisableWebviewContextMenu } from './hooks/shell/useDisableWebviewContextMenu';
 import { ThemeProvider } from './theme/ThemeProvider';
 import { AuthBoundary } from './auth/AuthBoundary';
@@ -50,6 +51,7 @@ function ProtectedLayout() {
   const focusSearch = useFocusSearch();
   useKeyboardShortcuts({ onFocusSearch: focusSearch });
   useTorrentFileOpen();
+  useMagnetLinkOpen();
   return (
     <AppShell>
       <Outlet />

--- a/apps/desktop/src/hooks/shell/useMagnetLinkOpen.ts
+++ b/apps/desktop/src/hooks/shell/useMagnetLinkOpen.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { openAddTorrentWindow } from '@/windows/dialogs/addTorrentWindow';
+
+/**
+ * Desktop-only hook that drains pending magnet URLs from Rust on mount
+ * and listens for live `magnet-link-open` events (from deep-link plugin
+ * callbacks on all platforms), then opens the Add Torrent auxiliary window
+ * with the magnet URL.
+ *
+ * Mount inside the authenticated shell (e.g. ProtectedLayout) so the session
+ * is available when the aux window opens.
+ */
+export function useMagnetLinkOpen(): void {
+  useEffect(() => {
+    // Register the live event listener first to avoid missing events that arrive
+    // between the drain call and listener registration.
+    const unlisten = listen<string[]>('magnet-link-open', async (event) => {
+      const urls = event.payload;
+      if (urls.length > 0) {
+        await openAddTorrentWindow({ url: urls[0] });
+        try {
+          await invoke('get_pending_magnet_links');
+        } catch {
+          // Non-fatal: the live event already delivered the URL to the Add Torrent window.
+        }
+      }
+    });
+
+    // Drain any magnet URLs that were queued before the renderer was ready (cold-start
+    // or tray-restore where the event fired before this listener registered).
+    async function drainPending(): Promise<void> {
+      try {
+        const urls: string[] = await invoke('get_pending_magnet_links');
+        if (urls.length > 0) {
+          await openAddTorrentWindow({ url: urls[0] });
+        }
+      } catch {
+        // Swallow — non-fatal if the command is not yet registered or queue is empty
+      }
+    }
+
+    void drainPending();
+
+    return () => {
+      void unlisten.then((fn) => fn());
+    };
+  }, []);
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -33,6 +33,7 @@
     "@taurent/web-ui": "workspace:*",
     "@tanstack/react-query": "^5.101.0",
     "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-http": "^2.5.9",

--- a/apps/mobile/src-tauri/src/lib.rs
+++ b/apps/mobile/src-tauri/src/lib.rs
@@ -7,10 +7,12 @@ use qb_tauri::commands::preferences;
 use qb_tauri::commands::tags;
 use qb_tauri::commands::torrents as qb_torrents;
 use qb_tauri::commands::transfer;
+use qb_tauri::magnet_links::PendingMagnetLinks;
 use qb_tauri::server_repo::init_and_manage_repository;
 use qb_tauri::session::create_session_state;
 use qb_tauri::sync::{create_sync_manager_registry, setup_sync_lifecycle};
-use tauri::Manager;
+use tauri::{Emitter, Manager};
+use tauri_plugin_deep_link::DeepLinkExt;
 
 use torrents::{add_tags, add_torrent, remove_tags, set_category};
 
@@ -18,6 +20,7 @@ use torrents::{add_tags, add_torrent, remove_tags, set_category};
 pub fn run() {
     let builder = add_shared_plugins(add_mobile_plugins(tauri::Builder::default()))
         .manage(create_session_state())
+        .manage(PendingMagnetLinks::new())
         .setup(|app| {
             // Initialize server repository with mobile-specific store file
             let server_repo = init_and_manage_repository(app.handle(), MOBILE_SERVER_STORE_FILE)
@@ -49,6 +52,29 @@ pub fn run() {
                             let _ = window.set_focus();
                         }
                     }))?;
+            }
+
+            // Register deep-link handler for magnet URLs arriving while the app is running.
+            {
+                let handle = app.handle().clone();
+                let _ = app.deep_link().on_open_url(move |event| {
+                    let urls: Vec<String> = event.urls().iter().map(|u| u.to_string()).collect();
+                    let pending = handle.state::<PendingMagnetLinks>();
+                    let new_urls = pending.enqueue(urls);
+                    if !new_urls.is_empty() {
+                        let _ = handle.emit("magnet-link-open", new_urls);
+                    }
+                });
+            }
+
+            // Check if the app was started via a deep link (cold-start).
+            {
+                let handle = app.handle();
+                if let Ok(Some(urls)) = app.deep_link().get_current() {
+                    let url_strings: Vec<String> = urls.iter().map(|u| u.to_string()).collect();
+                    let pending = handle.state::<PendingMagnetLinks>();
+                    pending.enqueue(url_strings);
+                }
             }
 
             Ok(())
@@ -110,6 +136,7 @@ pub fn run() {
             qb_torrents::get_torrent_trackers,
             qb_torrents::get_torrent_files,
             add_torrent,
+            qb_tauri::magnet_links::get_pending_magnet_links,
             qb_tauri::commands::sync::get_maindata_snapshot,
             qb_tauri::commands::sync::get_maindata_sync_status,
             qb_tauri::commands::sync::start_maindata_sync,

--- a/apps/mobile/src-tauri/tauri.conf.json
+++ b/apps/mobile/src-tauri/tauri.conf.json
@@ -51,7 +51,7 @@
     "deep-link": {
       "mobile": [
         {
-          "scheme": ["taurent"],
+          "scheme": ["magnet"],
           "appLink": false
         }
       ]

--- a/apps/mobile/src/hooks/useMagnetLinkOpen.ts
+++ b/apps/mobile/src/hooks/useMagnetLinkOpen.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * Mobile hook that drains pending magnet URLs from Rust on mount and listens for
+ * live `magnet-link-open` events, then navigates to the Add Torrent screen with
+ * the magnet URL pre-filled.
+ */
+export function useMagnetLinkOpen(): void {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Register the live event listener first.
+    const unlisten = listen<string[]>('magnet-link-open', async (event) => {
+      const urls = event.payload;
+      if (urls.length > 0) {
+        navigate(`/add-torrent?mode=magnet&url=${encodeURIComponent(urls[0])}`);
+        try {
+          await invoke('get_pending_magnet_links');
+        } catch {
+          // Non-fatal
+        }
+      }
+    });
+
+    // Drain pending on mount.
+    async function drainPending(): Promise<void> {
+      try {
+        const urls: string[] = await invoke('get_pending_magnet_links');
+        if (urls.length > 0) {
+          navigate(`/add-torrent?mode=magnet&url=${encodeURIComponent(urls[0])}`);
+        }
+      } catch {
+        // Swallow
+      }
+    }
+
+    void drainPending();
+
+    return () => {
+      void unlisten.then((fn) => fn());
+    };
+  }, [navigate]);
+}

--- a/apps/mobile/src/shell/MobileShell.tsx
+++ b/apps/mobile/src/shell/MobileShell.tsx
@@ -12,6 +12,7 @@ import type { CSSProperties } from 'react';
 import { WorkspaceFrame } from '@taurent/web-ui';
 import { Icon } from '../ui/Icon';
 import { MobileConnectionBanner } from './MobileConnectionBanner';
+import { useMagnetLinkOpen } from '../hooks/useMagnetLinkOpen';
 
 const MOBILE_TAB_BAR_SAFE_HEIGHT = 'calc(4rem + var(--sab, 0px))';
 
@@ -63,6 +64,7 @@ function MobileTabBar() {
 }
 
 export function MobileShell() {
+  useMagnetLinkOpen();
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background" style={mobileShellStyle}>
       <MobileConnectionBanner />

--- a/crates/qb-tauri/Cargo.toml
+++ b/crates/qb-tauri/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
-desktop = ["dep:tauri-plugin-clipboard-manager", "dep:tauri-plugin-window-state", "dep:tauri-plugin-dialog", "dep:tauri-plugin-shell", "dep:tauri-plugin-opener"]
+desktop = ["dep:tauri-plugin-clipboard-manager", "dep:tauri-plugin-window-state", "dep:tauri-plugin-dialog", "dep:tauri-plugin-shell", "dep:tauri-plugin-opener", "dep:tauri-plugin-deep-link"]
 mobile = ["dep:tauri-plugin-fs", "dep:tauri-plugin-dialog", "dep:tauri-plugin-deep-link", "dep:tauri-plugin-shell"]
 
 [dependencies]

--- a/crates/qb-tauri/src/app_builder.rs
+++ b/crates/qb-tauri/src/app_builder.rs
@@ -10,12 +10,13 @@ pub const DESKTOP_SERVER_STORE_FILE: &str = ".servers.dat";
 /// Server store filename for the mobile target.
 pub const MOBILE_SERVER_STORE_FILE: &str = ".mobile-settings.dat";
 
-/// Add plugins shared by all platforms (store, http, notification).
+/// Add plugins shared by all platforms (store, http, notification, deep-link).
 pub fn add_shared_plugins<R: tauri::Runtime>(builder: Builder<R>) -> Builder<R> {
     builder
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_deep_link::init())
 }
 
 /// Windows that are fixed-size and must not have their geometry restored.
@@ -67,13 +68,12 @@ pub fn add_desktop_plugins<R: tauri::Runtime>(builder: Builder<R>) -> Builder<R>
     builder
 }
 
-/// Add mobile-only plugins (fs, dialog, deep-link, shell, secure-storage).
+/// Add mobile-only plugins (fs, dialog, shell, secure-storage).
 #[cfg(feature = "mobile")]
 pub fn add_mobile_plugins<R: tauri::Runtime>(builder: Builder<R>) -> Builder<R> {
     builder
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_secure_storage::init())
 }

--- a/crates/qb-tauri/src/lib.rs
+++ b/crates/qb-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod app_builder;
 pub mod client;
 pub mod commands;
+pub mod magnet_links;
 pub mod server_repo;
 pub mod session;
 pub mod sync;

--- a/crates/qb-tauri/src/magnet_links.rs
+++ b/crates/qb-tauri/src/magnet_links.rs
@@ -1,0 +1,69 @@
+//! Pending magnet-link queue for deep-link resilience.
+//!
+//! When a magnet link arrives while the renderer is torn down (e.g. tray mode),
+//! the Rust callback enqueues URLs here. The frontend drains them on mount via
+//! the `get_pending_magnet_links` command.
+
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use tauri::Manager;
+
+/// Holds queued magnet URLs with dedup to avoid re-queuing the same URL
+/// across cold-start, single-instance, and on_open_url events.
+pub struct PendingMagnetLinks {
+    queue: Mutex<Vec<String>>,
+    seen: Mutex<HashSet<String>>,
+}
+
+impl Default for PendingMagnetLinks {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PendingMagnetLinks {
+    pub fn new() -> Self {
+        Self {
+            queue: Mutex::new(Vec::new()),
+            seen: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// Enqueue `urls`, adding each to `seen` first so duplicates across sources
+    /// are suppressed. Returns only the genuinely new URLs.
+    pub fn enqueue(&self, urls: Vec<String>) -> Vec<String> {
+        let mut seen = self.seen.lock().unwrap();
+        let mut queue = self.queue.lock().unwrap();
+        let mut new_urls = Vec::with_capacity(urls.len());
+        for url in urls {
+            if seen.insert(url.clone()) {
+                queue.push(url.clone());
+                new_urls.push(url);
+            }
+        }
+        drop(queue);
+        new_urls
+    }
+
+    pub fn drain(&self) -> Vec<String> {
+        let mut queue = self.queue.lock().unwrap();
+        let drained = std::mem::take(&mut *queue);
+        drop(queue);
+
+        let mut seen = self.seen.lock().unwrap();
+        for url in &drained {
+            seen.remove(url);
+        }
+        drop(seen);
+
+        drained
+    }
+}
+
+/// Tauri command: drain pending magnet URLs for the frontend.
+#[tauri::command]
+pub fn get_pending_magnet_links(app: tauri::AppHandle) -> Vec<String> {
+    let pending = app.state::<PendingMagnetLinks>();
+    pending.drain()
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@tauri-apps/plugin-clipboard-manager':
         specifier: ^2.3.2
         version: 2.3.2
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
@@ -228,6 +231,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.1
         version: 2.11.1
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
@@ -1235,6 +1241,9 @@ packages:
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
@@ -4298,6 +4307,10 @@ snapshots:
       '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
     dependencies:
       '@tauri-apps/api': 2.11.1
 


### PR DESCRIPTION
- Rust: PendingMagnetLinks queue+drain in shared qb-tauri crate
- Desktop: MagnetLinkOpen handler wired to single-instance callback, on_open_url + get_current for macOS/Windows/Linux deep links
- Mobile: on_open_url + get_current in setup
- Config: register 'magnet' scheme in both tauri.conf.json files
- Frontend: useMagnetLinkOpen hooks for desktop (aux window) and mobile (React Router navigation), mounted in authenticated shells