### PR TITLE
ci: remove aggregate PR CI summary job

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -204,21 +204,4 @@ jobs:
           path: artifacts/desktop/perf/native-smoke.json
           if-no-files-found: warn
 
-  pr-ci-summary:
-    name: PR CI Summary
-    needs: [js-quality, rust-quality, native-smoke]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
 
-      - name: Write aggregate summary
-        env:
-          CI_JOB_KIND: aggregate
-          CI_JS_RESULT: ${{ needs.js-quality.result }}
-          CI_RUST_RESULT: ${{ needs.rust-quality.result }}
-          CI_SMOKE_RESULT: ${{ needs.native-smoke.result }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: node scripts/ci/write-pr-ci-summary.mjs

--- a/scripts/ci/codemap.md
+++ b/scripts/ci/codemap.md
@@ -8,7 +8,7 @@ CI validation scripts covering two concerns: version consistency across workspac
 
 Three independent entrypoints: `check-versions.mjs` (Node), `runs-coverage.sh` (shell), and `write-pr-ci-summary.mjs` (Node). They share no library, run in isolation, and exit non-zero on failure so CI fails the build.
 
-- `write-pr-ci-summary.mjs`: Writes compact Markdown job summaries to `GITHUB_STEP_SUMMARY` for `pr-ci.yml` jobs. Supports js-quality, rust-quality, native-smoke, and aggregate lanes.
+- `write-pr-ci-summary.mjs`: Writes compact Markdown job summaries to `GITHUB_STEP_SUMMARY` for `pr-ci.yml` jobs. Supports js-quality, rust-quality, and native-smoke lanes.
 
 ## Flow
 


### PR DESCRIPTION
Each job already writes its own summary via GITHUB_STEP_SUMMARY, making the aggregate pr-ci-summary job redundant.