### PR TITLE
feat(theme): change default theme to Catppuccin, respect system variant

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -161,7 +161,7 @@ function AppContent() {
 
   return (
     <SearchFocusProvider>
-      <ThemeProvider defaultTheme="solarized-dark">
+      <ThemeProvider defaultTheme="catppuccin">
         <ServerManagerProvider>
           <QBClientProvider>
             <AppNotifications />

--- a/apps/desktop/src/theme/ThemeProvider.tsx
+++ b/apps/desktop/src/theme/ThemeProvider.tsx
@@ -25,7 +25,7 @@ function getThemeEventSignature(event: ThemeChangedEvent) {
  * 1. Wraps the shared web-ui ThemeProvider (which reads/writes localStorage synchronously)
  * 2. Synchronizes theme changes across Tauri desktop windows via theme-changed events
  */
-export function ThemeProvider({ children, defaultTheme = 'solarized-dark' }: { children: ReactNode; defaultTheme?: string }) {
+export function ThemeProvider({ children, defaultTheme = 'catppuccin' }: { children: ReactNode; defaultTheme?: string }) {
   return (
     <SharedThemeProvider defaultTheme={defaultTheme}>
       <DesktopThemeEventBridge />

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -88,7 +88,7 @@ function AppNotifications() {
 function AppContent() {
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider defaultTheme="solarized-dark">
+      <ThemeProvider defaultTheme="catppuccin">
         <ControlDensityProvider>
           <ServerManagerProvider>
             <QBClientProvider>

--- a/packages/shared/src/theme/background.ts
+++ b/packages/shared/src/theme/background.ts
@@ -26,7 +26,7 @@ export const THEME_BACKGROUND_COLORS = {
 } as const satisfies Record<string, string>;
 
 /** Default fallback background used when theme resolution fails. */
-export const DEFAULT_THEME_BACKGROUND = '#002b36';
+export const DEFAULT_THEME_BACKGROUND = '#1e1e2e';
 
 /** Convert a hex color string (#rrggbb or #rrggbbaa) to an RGBA tuple for Tauri's Color type. */
 export function hexToRgba(hex: string): [number, number, number, number] {
@@ -52,7 +52,7 @@ export function getThemeBackground(themeClass: string): string {
 export function generateThemeBackgroundStyles(): string {
   const rules: string[] = [`html,body{background-color:${DEFAULT_THEME_BACKGROUND};}`];
   for (const [cls, color] of Object.entries(THEME_BACKGROUND_COLORS)) {
-    if (cls !== 'theme-solarized-dark') {
+    if (cls !== 'theme-catppuccin-mocha') {
       rules.push(`html.${cls}{background-color:${color};}`);
     }
   }
@@ -78,11 +78,11 @@ export function generateThemeInitScript(): string {
     `function c(p,v){if(p==='catppuccin')return 'theme-catppuccin-'+(v==='dark'?'mocha':'latte');` +
     `if(d.indexOf(p)!==-1)return 'theme-'+p;return 'theme-'+p+'-'+v;}` +
     `function s(){return typeof matchMedia==='function'&&matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}` +
-    `var p='solarized',v=s(),m=localStorage.getItem('app_theme_mode');` +
-    `if(m==='system'){p=localStorage.getItem('app_system_palette')||'solarized';` +
+    `var p='catppuccin',v=s(),m=localStorage.getItem('app_theme_mode');` +
+    `if(m==='system'){p=localStorage.getItem('app_system_palette')||'catppuccin';` +
     `v=s();}` +
-    `else if(m==='manual'){p=localStorage.getItem('app_manual_palette')||'solarized';` +
-    `v=localStorage.getItem('app_manual_variant')||'dark';}` +
+    `else if(m==='manual'){p=localStorage.getItem('app_manual_palette')||'catppuccin';` +
+    `v=localStorage.getItem('app_manual_variant')||s();}` +
     `if(d.indexOf(p)!==-1)v='dark';` +
     `document.documentElement.className=c(p,v);` +
     `}catch(e){}})();`

--- a/packages/shared/src/theme/backgroundRuntime.ts
+++ b/packages/shared/src/theme/backgroundRuntime.ts
@@ -21,14 +21,14 @@ function getSystemThemeVariant(): ThemeVariant {
 export function resolveCurrentThemeBackground(): string {
   try {
     const mode = localStorage.getItem('app_theme_mode');
-    let palette: ThemePalette = 'solarized';
+    let palette: ThemePalette = 'catppuccin';
     let variant: ThemeVariant = getSystemThemeVariant();
 
     if (mode === 'system') {
-      palette = (localStorage.getItem('app_system_palette') ?? 'solarized') as ThemePalette;
+      palette = (localStorage.getItem('app_system_palette') ?? 'catppuccin') as ThemePalette;
       variant = getSystemThemeVariant();
     } else if (mode === 'manual') {
-      palette = (localStorage.getItem('app_manual_palette') ?? 'solarized') as ThemePalette;
+      palette = (localStorage.getItem('app_manual_palette') ?? 'catppuccin') as ThemePalette;
       variant = (localStorage.getItem('app_manual_variant') ?? 'dark') as ThemeVariant;
     }
 
@@ -46,5 +46,5 @@ export function resolveCurrentThemeBackgroundRgba(): [number, number, number, nu
 
 /** Resolve an OS-scheme background for native window creation/chrome. */
 export function resolveSystemThemeBackgroundRgba(): [number, number, number, number] {
-  return hexToRgba(getSystemThemeVariant() === 'dark' ? DEFAULT_THEME_BACKGROUND : getThemeBackground('theme-solarized-light'));
+  return hexToRgba(getSystemThemeVariant() === 'dark' ? DEFAULT_THEME_BACKGROUND : getThemeBackground('theme-catppuccin-latte'));
 }

--- a/packages/shared/src/theme/registry.ts
+++ b/packages/shared/src/theme/registry.ts
@@ -26,16 +26,16 @@ export interface ThemePaletteMetadata {
  */
 export const THEME_OPTIONS: ThemePaletteMetadata[] = [
   {
-    palette: 'solarized',
-    label: 'Solarized',
-    description: 'Classic precision color scheme',
+    palette: 'catppuccin',
+    label: 'Catppuccin',
+    description: 'Soothing pastel theme',
     darkOnly: false,
     variants: ['light', 'dark'],
   },
   {
-    palette: 'catppuccin',
-    label: 'Catppuccin',
-    description: 'Soothing pastel theme',
+    palette: 'solarized',
+    label: 'Solarized',
+    description: 'Classic precision color scheme',
     darkOnly: false,
     variants: ['light', 'dark'],
   },

--- a/packages/shared/src/theme/resolver.ts
+++ b/packages/shared/src/theme/resolver.ts
@@ -107,9 +107,3 @@ export function resolveEffectiveClass(id: string): string {
   return resolveThemeClass(parsed.palette, parsed.variant);
 }
 
-/**
- * Get the default palette/variant for a new desktop installation.
- */
-export function getDefaultThemeSelection(): { palette: ThemePalette; variant: ThemeVariant } {
-  return { palette: 'solarized', variant: 'dark' };
-}

--- a/packages/web-ui/src/theme/ThemeProvider.tsx
+++ b/packages/web-ui/src/theme/ThemeProvider.tsx
@@ -147,9 +147,9 @@ function readConfigFromStorage(defaultTheme: string): ThemeConfig {
 
       return {
         mode: savedMode as ThemeMode,
-        systemPalette: savedSystemPalette as ThemePalette ?? 'solarized',
-        manualPalette: savedManualPalette as ThemePalette ?? 'solarized',
-        manualVariant: savedManualVariant ?? 'dark',
+        systemPalette: savedSystemPalette as ThemePalette ?? 'catppuccin',
+        manualPalette: savedManualPalette as ThemePalette ?? 'catppuccin',
+        manualVariant: savedManualVariant ?? getSystemScheme(),
         accent: savedAccent && /^#[0-9a-f]{6}$/i.test(savedAccent) ? savedAccent as AccentPreference : null,
       };
     }
@@ -161,9 +161,9 @@ function readConfigFromStorage(defaultTheme: string): ThemeConfig {
   const parsed = parseThemeId(defaultTheme);
   return {
     mode: 'system',
-    systemPalette: parsed?.palette ?? 'solarized',
-    manualPalette: parsed?.palette ?? 'solarized',
-    manualVariant: parsed?.variant ?? 'dark',
+    systemPalette: parsed?.palette ?? 'catppuccin',
+    manualPalette: parsed?.palette ?? 'catppuccin',
+    manualVariant: parsed?.variant ?? getSystemScheme(),
     accent: null,
   };
 }
@@ -173,7 +173,7 @@ export interface ThemeProviderProps {
   defaultTheme?: string;
 }
 
-export function ThemeProvider({ children, defaultTheme = 'solarized-dark' }: ThemeProviderProps) {
+export function ThemeProvider({ children, defaultTheme = 'catppuccin' }: ThemeProviderProps) {
   // Initialize synchronously from localStorage — no async effect needed.
   // This ensures the initial themeClass matches what the inline init script set,
   // preventing any flash of a wrong theme on first render.


### PR DESCRIPTION
- Move Catppuccin to first position in THEME_OPTIONS (selector order)
- Change defaultTheme from 'solarized-dark' to 'catppuccin' across all providers
- Update fallback defaults in readConfigFromStorage, background init script, and backgroundRuntime to use Catppuccin palette
- Default background color to #1e1e2e (Catppuccin Mocha) for init flash
- Make manual variant fallback system-aware (getSystemScheme) instead of hardcoding 'dark'