### PR TITLE
fix(e2e): add more recoverable WebDriver transport error patterns

### DIFF
--- a/apps/desktop/scripts/e2e/runner.ts
+++ b/apps/desktop/scripts/e2e/runner.ts
@@ -97,6 +97,10 @@ function isRecoverableWebDriverTransportError(error: unknown): boolean {
     'socket hang up',
     'fetch failed',
     'terminated',
+    'unable to connect',
+    'browser driver is running',
+    'service failed to start',
+    'rejecting any connections',
   ].some((needle) => normalized.includes(needle));
 }
 

--- a/apps/desktop/scripts/e2e/webdriver.ts
+++ b/apps/desktop/scripts/e2e/webdriver.ts
@@ -58,6 +58,10 @@ function isRecoverableSessionError(error: unknown): boolean {
     'socket hang up',
     'terminated',
     'timeout',
+    'unable to connect',
+    'browser driver is running',
+    'service failed to start',
+    'rejecting any connections',
   ].some((needle) => message.includes(needle));
 }
 


### PR DESCRIPTION
- 'unable to connect', 'browser driver is running', 'service failed to start', 'rejecting any connections'