### PR TITLE
feat(search): add sortable search results

### DIFF
--- a/apps/desktop/src/screens/SearchScreen.tsx
+++ b/apps/desktop/src/screens/SearchScreen.tsx
@@ -44,6 +44,10 @@ export function SearchScreen() {
         searchResults={model.searchResults}
         currentResultsTotal={model.currentResultsTotal}
         isLoadingResults={model.isLoadingResults}
+        sortKey={model.sortKey}
+        sortDirection={model.sortDirection}
+        onSortKeyChange={model.setSortKey}
+        onSortDirectionChange={model.setSortDirection}
         plugins={model.plugins}
         isLoadingPlugins={model.isLoadingPlugins}
         pluginsError={model.pluginsError}

--- a/apps/mobile/src/screens/SearchScreen.tsx
+++ b/apps/mobile/src/screens/SearchScreen.tsx
@@ -43,6 +43,10 @@ export function SearchScreen() {
           searchResults={model.searchResults}
           currentResultsTotal={model.currentResultsTotal}
           isLoadingResults={model.isLoadingResults}
+          sortKey={model.sortKey}
+          sortDirection={model.sortDirection}
+          onSortKeyChange={model.setSortKey}
+          onSortDirectionChange={model.setSortDirection}
           plugins={model.plugins}
           isLoadingPlugins={model.isLoadingPlugins}
           pluginsError={model.pluginsError}

--- a/packages/web-core/src/search/__tests__/sortSearchResults.test.ts
+++ b/packages/web-core/src/search/__tests__/sortSearchResults.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import type { SearchResult } from '@taurent/bridge';
+import {
+  sortSearchResults,
+  DEFAULT_SEARCH_SORT_KEY,
+  DEFAULT_SEARCH_SORT_DIRECTION,
+} from '../sortSearchResults';
+
+function makeResult(overrides: Partial<SearchResult> = {}): SearchResult {
+  return {
+    descrLink: '',
+    fileName: 'file',
+    fileSize: 0,
+    fileUrl: '',
+    nbLeechers: 0,
+    nbSeeders: 0,
+    siteUrl: '',
+    ...overrides,
+  };
+}
+
+const names = (results: readonly SearchResult[]) => results.map((r) => r.fileName);
+
+describe('sortSearchResults', () => {
+  it('sorts by seeders descending', () => {
+    const results = [
+      makeResult({ fileName: 'a', nbSeeders: 5 }),
+      makeResult({ fileName: 'b', nbSeeders: 50 }),
+      makeResult({ fileName: 'c', nbSeeders: 12 }),
+    ];
+    expect(names(sortSearchResults(results, 'seeders', 'desc'))).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts by seeders ascending', () => {
+    const results = [
+      makeResult({ fileName: 'a', nbSeeders: 5 }),
+      makeResult({ fileName: 'b', nbSeeders: 50 }),
+      makeResult({ fileName: 'c', nbSeeders: 12 }),
+    ];
+    expect(names(sortSearchResults(results, 'seeders', 'asc'))).toEqual(['a', 'c', 'b']);
+  });
+
+  it('sorts by leechers', () => {
+    const results = [
+      makeResult({ fileName: 'a', nbLeechers: 3 }),
+      makeResult({ fileName: 'b', nbLeechers: 1 }),
+      makeResult({ fileName: 'c', nbLeechers: 9 }),
+    ];
+    expect(names(sortSearchResults(results, 'leechers', 'desc'))).toEqual(['c', 'a', 'b']);
+    expect(names(sortSearchResults(results, 'leechers', 'asc'))).toEqual(['b', 'a', 'c']);
+  });
+
+  it('sorts by size', () => {
+    const results = [
+      makeResult({ fileName: 'a', fileSize: 5_000 }),
+      makeResult({ fileName: 'b', fileSize: 5_000_000_000 }),
+      makeResult({ fileName: 'c', fileSize: 500 }),
+    ];
+    expect(names(sortSearchResults(results, 'size', 'desc'))).toEqual(['b', 'a', 'c']);
+    expect(names(sortSearchResults(results, 'size', 'asc'))).toEqual(['c', 'a', 'b']);
+  });
+
+  it('sorts by name case-insensitively and numerically', () => {
+    const results = [
+      makeResult({ fileName: 'Zeta' }),
+      makeResult({ fileName: 'alpha' }),
+      makeResult({ fileName: 'file10' }),
+      makeResult({ fileName: 'file2' }),
+    ];
+    // Ascending: case-insensitive alpha order, digits compared numerically.
+    expect(names(sortSearchResults(results, 'name', 'asc'))).toEqual([
+      'alpha',
+      'file2',
+      'file10',
+      'Zeta',
+    ]);
+    expect(names(sortSearchResults(results, 'name', 'desc'))).toEqual([
+      'Zeta',
+      'file10',
+      'file2',
+      'alpha',
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const results = [
+      makeResult({ fileName: 'a', nbSeeders: 1 }),
+      makeResult({ fileName: 'b', nbSeeders: 2 }),
+    ];
+    const snapshot = names(results);
+    sortSearchResults(results, 'seeders', 'desc');
+    expect(names(results)).toEqual(snapshot);
+  });
+
+  it('is stable for equal keys', () => {
+    const results = [
+      makeResult({ fileName: 'first', nbSeeders: 10 }),
+      makeResult({ fileName: 'second', nbSeeders: 10 }),
+      makeResult({ fileName: 'third', nbSeeders: 10 }),
+    ];
+    expect(names(sortSearchResults(results, 'seeders', 'desc'))).toEqual([
+      'first',
+      'second',
+      'third',
+    ]);
+  });
+
+  it('treats -1 unknown sentinels as smallest and sorts them last when descending', () => {
+    const results = [
+      makeResult({ fileName: 'known', nbSeeders: 4 }),
+      makeResult({ fileName: 'unknown', nbSeeders: -1 }),
+      makeResult({ fileName: 'more', nbSeeders: 8 }),
+    ];
+    expect(names(sortSearchResults(results, 'seeders', 'desc'))).toEqual([
+      'more',
+      'known',
+      'unknown',
+    ]);
+  });
+
+  it('handles empty input', () => {
+    expect(sortSearchResults([], 'seeders', 'desc')).toEqual([]);
+  });
+
+  it('exposes sensible defaults', () => {
+    expect(DEFAULT_SEARCH_SORT_KEY).toBe('seeders');
+    expect(DEFAULT_SEARCH_SORT_DIRECTION).toBe('desc');
+  });
+});

--- a/packages/web-core/src/search/codemap.md
+++ b/packages/web-core/src/search/codemap.md
@@ -7,9 +7,10 @@ Capability-gated search controller and screen model hooks. Provides the full sea
 ## Key Files
 
 - `index.ts` — Barrel export
-- `useSearchController.ts` — Main hook that manages search execution, result polling (2s interval), plugin CRUD, and typed bridge DTO consumption; accepts `SearchAdapters` interface
-- `useSearchScreenModel.ts` — Composes `useSearchController` with the `onAddResult` callback for platform-specific add-torrent behavior
+- `useSearchController.ts` — Main hook that manages search execution, result polling (2s interval), plugin CRUD, result ordering state, and typed bridge DTO consumption; accepts `SearchAdapters` interface
+- `useSearchScreenModel.ts` — Composes `useSearchController` with the `onAddResult` callback for platform-specific add-torrent behavior; passes through result-ordering state
 - `createSearchAdapters.ts` — Adapter factory that constructs `SearchAdapters` from a `QBClientBridge`; moves bridge bundle construction from app-level screens into shared web-core
+- `sortSearchResults.ts` — Pure, non-mutating result ordering helper (`sortSearchResults`) plus `SearchSortKey`/`SearchSortDirection` types and defaults (seeders, descending); fully unit tested
 
 ## Design Patterns
 
@@ -20,6 +21,7 @@ Capability-gated search controller and screen model hooks. Provides the full sea
 - **Error threshold**: Stops polling after 5 consecutive failures to prevent infinite error loops
 - **Typed boundary consumption**: Search status/results/plugins arrive as typed bridge DTOs (`SearchStatus[]`, `SearchResults`, `SearchPlugin[]`); the controller keeps only narrow UI helpers such as status label mapping and plugin-category defaults
 - **Platform-specific add result**: `onAddResult` is a required callback so desktop (aux window) and mobile (navigation) can wire their own add-torrent flow
+- **Result ordering**: `sortKey`/`sortDirection` state (default seeders/descending) drives a memoized, non-mutating sort of the fetched results via `sortSearchResults`; the ordered array is what consumers read from `searchResults`
 
 ## Flow
 

--- a/packages/web-core/src/search/index.ts
+++ b/packages/web-core/src/search/index.ts
@@ -3,3 +3,9 @@
 export * from './useSearchController';
 export * from './useSearchScreenModel';
 export { createSearchAdapters } from './createSearchAdapters';
+export {
+  sortSearchResults,
+  DEFAULT_SEARCH_SORT_KEY,
+  DEFAULT_SEARCH_SORT_DIRECTION,
+} from './sortSearchResults';
+export type { SearchSortKey, SearchSortDirection } from './sortSearchResults';

--- a/packages/web-core/src/search/sortSearchResults.ts
+++ b/packages/web-core/src/search/sortSearchResults.ts
@@ -1,0 +1,58 @@
+/**
+ * Search result sorting
+ *
+ * Pure, side-effect-free helpers for ordering the search-result rows returned
+ * by the backend. qBittorrent returns results in plugin-emission order, which
+ * is rarely what a user wants — sorting by seeder count (or size/name) makes
+ * the list far more useful. The logic lives here (headless) so both the
+ * desktop and mobile SearchScreens share identical, unit-tested behaviour.
+ */
+
+import type { SearchResult } from '@taurent/bridge';
+
+/** Field a search-result list can be ordered by. */
+export type SearchSortKey = 'seeders' | 'leechers' | 'size' | 'name';
+
+/** Sort direction. `desc` places the largest / highest value first. */
+export type SearchSortDirection = 'asc' | 'desc';
+
+/** Default ordering: most seeders first, the most common torrent-picking heuristic. */
+export const DEFAULT_SEARCH_SORT_KEY: SearchSortKey = 'seeders';
+export const DEFAULT_SEARCH_SORT_DIRECTION: SearchSortDirection = 'desc';
+
+function compareByKey(a: SearchResult, b: SearchResult, key: SearchSortKey): number {
+  switch (key) {
+    case 'name':
+      // Locale-aware, case-insensitive, and digit-aware so "file2" < "file10".
+      return a.fileName.localeCompare(b.fileName, undefined, {
+        sensitivity: 'base',
+        numeric: true,
+      });
+    case 'size':
+      return a.fileSize - b.fileSize;
+    case 'leechers':
+      return a.nbLeechers - b.nbLeechers;
+    case 'seeders':
+      return a.nbSeeders - b.nbSeeders;
+  }
+}
+
+/**
+ * Return a new array of `results` ordered by `sortKey`/`direction`.
+ *
+ * The input is never mutated. The sort is stable (relies on the ES2019+
+ * `Array.prototype.sort` stability guarantee), so rows that compare equal keep
+ * their original relative order. Numeric comparisons treat qBittorrent's
+ * `-1` "unknown" sentinel as an ordinary small value, which naturally sorts
+ * such rows to the bottom in descending order.
+ */
+export function sortSearchResults(
+  results: readonly SearchResult[],
+  sortKey: SearchSortKey,
+  direction: SearchSortDirection,
+): SearchResult[] {
+  const directionMultiplier = direction === 'asc' ? 1 : -1;
+  return [...results].sort(
+    (a, b) => compareByKey(a, b, sortKey) * directionMultiplier,
+  );
+}

--- a/packages/web-core/src/search/useSearchController.ts
+++ b/packages/web-core/src/search/useSearchController.ts
@@ -31,7 +31,7 @@
  *   });
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { formatUserMessageForContext } from '@taurent/shared/utils/error';
 import type {
@@ -42,6 +42,13 @@ import type {
   SearchStatus,
 } from '@taurent/bridge';
 import type { QueryScope } from '../query/scope';
+import {
+  sortSearchResults,
+  DEFAULT_SEARCH_SORT_KEY,
+  DEFAULT_SEARCH_SORT_DIRECTION,
+  type SearchSortKey,
+  type SearchSortDirection,
+} from './sortSearchResults';
 
 // ---------------------------------------------------------------------------
 // UI-facing status label
@@ -118,10 +125,16 @@ export interface UseSearchControllerResult {
   stopSearch: () => Promise<void>;
   deleteSearch: (id: number) => Promise<void>;
 
-  // Current search results (latest fetched)
+  // Current search results (latest fetched), ordered by the active sort
   searchResults: SearchResults['results'];
   currentResultsTotal: number;
   isLoadingResults: boolean;
+
+  // Result ordering
+  sortKey: SearchSortKey;
+  sortDirection: SearchSortDirection;
+  setSortKey: (key: SearchSortKey) => void;
+  setSortDirection: (direction: SearchSortDirection) => void;
 
   // Plugin list
   plugins: NormalizedSearchPlugin[];
@@ -235,6 +248,17 @@ export function useSearchController({
   const [currentResultsTotal, setCurrentResultsTotal] = useState(0);
   const [isLoadingResults, setIsLoadingResults] = useState(false);
   const [isPluginActionPending, setIsPluginActionPending] = useState(false);
+
+  // ─── Result ordering state ──────────────────────────────────────────────
+  const [sortKey, setSortKey] = useState<SearchSortKey>(DEFAULT_SEARCH_SORT_KEY);
+  const [sortDirection, setSortDirection] = useState<SearchSortDirection>(
+    DEFAULT_SEARCH_SORT_DIRECTION,
+  );
+
+  const sortedResults = useMemo(
+    () => sortSearchResults(searchResults, sortKey, sortDirection),
+    [searchResults, sortKey, sortDirection],
+  );
 
   // Error counter to stop polling after repeated failures
   const searchErrorCountRef = useRef(0);
@@ -477,9 +501,14 @@ export function useSearchController({
     stopSearch: stopSearchFn,
     deleteSearch: deleteSearchFn,
 
-    searchResults,
+    searchResults: sortedResults,
     currentResultsTotal,
     isLoadingResults,
+
+    sortKey,
+    sortDirection,
+    setSortKey,
+    setSortDirection,
 
     plugins: pluginsQuery.data ?? [],
     isLoadingPlugins: pluginsQuery.isLoading,

--- a/packages/web-core/src/search/useSearchScreenModel.ts
+++ b/packages/web-core/src/search/useSearchScreenModel.ts
@@ -24,6 +24,7 @@ import type {
   NormalizedSearchResult,
   NormalizedSearchPlugin,
 } from './useSearchController';
+import type { SearchSortKey, SearchSortDirection } from './sortSearchResults';
 
 export interface UseSearchScreenModelOptions {
   scope: QueryScope;
@@ -63,6 +64,12 @@ export interface UseSearchScreenModelResult {
   searchResults: NormalizedSearchResult[];
   currentResultsTotal: number;
   isLoadingResults: boolean;
+
+  // Result ordering
+  sortKey: SearchSortKey;
+  sortDirection: SearchSortDirection;
+  setSortKey: (key: SearchSortKey) => void;
+  setSortDirection: (direction: SearchSortDirection) => void;
 
   // Plugins
   plugins: NormalizedSearchPlugin[];
@@ -115,6 +122,11 @@ export function useSearchScreenModel({
     searchResults: controller.searchResults,
     currentResultsTotal: controller.currentResultsTotal,
     isLoadingResults: controller.isLoadingResults,
+
+    sortKey: controller.sortKey,
+    sortDirection: controller.sortDirection,
+    setSortKey: controller.setSortKey,
+    setSortDirection: controller.setSortDirection,
 
     plugins: controller.plugins,
     isLoadingPlugins: controller.isLoadingPlugins,

--- a/packages/web-ui/src/index.ts
+++ b/packages/web-ui/src/index.ts
@@ -193,7 +193,7 @@ export type { AuthLoadingScreenProps } from './components/server-setup/AuthLoadi
 export { HomeScreenBody } from './screens/HomeScreen';
 export type { HomeScreenProps, SortOption, FilterSummaryItem } from './screens/HomeScreen';
 export { SearchScreenBody } from './screens/SearchScreen';
-export type { SearchScreenProps, NormalizedSearchPlugin, NormalizedSearchResult } from './screens/SearchScreen';
+export type { SearchScreenProps, NormalizedSearchPlugin, NormalizedSearchResult, SearchSortKey, SearchSortDirection } from './screens/SearchScreen';
 export { RSSScreenBody } from './screens/RSSScreen';
 export type {
   RSSScreenProps,

--- a/packages/web-ui/src/screens/SearchScreen/SearchScreenBody.tsx
+++ b/packages/web-ui/src/screens/SearchScreen/SearchScreenBody.tsx
@@ -4,6 +4,8 @@ import { StateSurface } from '../../components/shared/StateSurface';
 import { SkeletonBlock } from '../../components/shared/SkeletonBlock';
 import { ConfirmDialog } from '../../components/dialogs/ConfirmDialog';
 import { Input } from '../../components/primitives/Input';
+import { Select } from '../../components/primitives/Select';
+import type { SelectOption } from '../../components/primitives/Select';
 import { PluginInstallDialog } from '../../components/dialogs/PluginInstallDialog';
 import {
   filledVariantClasses,
@@ -33,6 +35,16 @@ export interface NormalizedSearchResult {
   siteUrl: string;
 }
 
+export type SearchSortKey = 'seeders' | 'leechers' | 'size' | 'name';
+export type SearchSortDirection = 'asc' | 'desc';
+
+const SORT_KEY_OPTIONS: SelectOption<SearchSortKey>[] = [
+  { value: 'seeders', label: 'Seeders' },
+  { value: 'leechers', label: 'Leechers' },
+  { value: 'size', label: 'Size' },
+  { value: 'name', label: 'Name' },
+];
+
 export interface SearchScreenProps {
   variant?: 'desktop' | 'mobile';
   // Capability state
@@ -55,6 +67,11 @@ export interface SearchScreenProps {
   searchResults: NormalizedSearchResult[];
   currentResultsTotal: number;
   isLoadingResults: boolean;
+  // Result ordering (optional; when omitted, the sort control is hidden)
+  sortKey?: SearchSortKey;
+  sortDirection?: SearchSortDirection;
+  onSortKeyChange?: (key: SearchSortKey) => void;
+  onSortDirectionChange?: (direction: SearchSortDirection) => void;
   // Plugins
   plugins: NormalizedSearchPlugin[];
   isLoadingPlugins: boolean;
@@ -125,6 +142,45 @@ const SearchResultRow = React.memo<SearchResultRowProps>(({ result, onAdd }) => 
 ));
 
 SearchResultRow.displayName = 'SearchResultRow';
+
+interface SortControlProps {
+  sortKey: SearchSortKey;
+  sortDirection: SearchSortDirection;
+  onSortKeyChange: (key: SearchSortKey) => void;
+  onSortDirectionChange: (direction: SearchSortDirection) => void;
+}
+
+const SortControl = React.memo<SortControlProps>(
+  ({ sortKey, sortDirection, onSortKeyChange, onSortDirectionChange }) => {
+    const isDescending = sortDirection === 'desc';
+    return (
+      <div className="flex shrink-0 items-center gap-2">
+        <span className="text-xs text-text-muted">Sort</span>
+        <Select<SearchSortKey>
+          options={SORT_KEY_OPTIONS}
+          value={sortKey}
+          onChange={onSortKeyChange}
+          containerClassName="w-28"
+          aria-label="Sort results by"
+        />
+        <button
+          type="button"
+          onClick={() => onSortDirectionChange(isDescending ? 'asc' : 'desc')}
+          aria-label={isDescending ? 'Sort descending (highest first)' : 'Sort ascending (lowest first)'}
+          title={isDescending ? 'Descending' : 'Ascending'}
+          className={cn(
+            'flex shrink-0 items-center justify-center rounded-sm p-2 text-text-secondary',
+            surfaceVariantClasses({ border: 'border-border', hoverBg: 'bg-surface-interactive' }),
+          )}
+        >
+          <Icon name={isDescending ? 'chevron-down' : 'chevron-up'} className="h-4 w-4" />
+        </button>
+      </div>
+    );
+  },
+);
+
+SortControl.displayName = 'SortControl';
 
 interface PluginCardProps {
   plugin: NormalizedSearchPlugin;
@@ -206,6 +262,10 @@ export const SearchScreenBody = React.memo<SearchScreenProps>(({
   searchResults,
   currentResultsTotal,
   isLoadingResults,
+  sortKey,
+  sortDirection,
+  onSortKeyChange,
+  onSortDirectionChange,
   plugins,
   isLoadingPlugins,
   pluginsError,
@@ -426,11 +486,23 @@ export const SearchScreenBody = React.memo<SearchScreenProps>(({
           </div>
         ) : (
           <div className={cn('space-y-2', isCompact ? 'p-4' : 'p-4')}>
-            {currentResultsTotal > 0 && !isSearching && (
-              <p className="mb-2 text-xs text-text-muted">
-                {currentResultsTotal} result{currentResultsTotal === 1 ? '' : 's'} found
-              </p>
-            )}
+            <div className="mb-2 flex items-center justify-between gap-2">
+              {currentResultsTotal > 0 && !isSearching ? (
+                <p className="text-xs text-text-muted">
+                  {currentResultsTotal} result{currentResultsTotal === 1 ? '' : 's'} found
+                </p>
+              ) : (
+                <span aria-hidden="true" />
+              )}
+              {sortKey && sortDirection && onSortKeyChange && onSortDirectionChange ? (
+                <SortControl
+                  sortKey={sortKey}
+                  sortDirection={sortDirection}
+                  onSortKeyChange={onSortKeyChange}
+                  onSortDirectionChange={onSortDirectionChange}
+                />
+              ) : null}
+            </div>
             {searchResults.map((result, index) => (
               <SearchResultRow
                 key={`${result.fileName}-${index}`}

--- a/packages/web-ui/src/screens/SearchScreen/codemap.md
+++ b/packages/web-ui/src/screens/SearchScreen/codemap.md
@@ -7,8 +7,9 @@ Provides the platform-agnostic presentational body for the qBittorrent search pl
 ## Design
 
 - **`SearchScreenBody`** — top-level `React.memo` component (`SearchScreenProps`). Handles capability gating (loading → unsupported → offline → ready), local query state synced with prop, and three visual zones: search input, plugin management (collapsible), and results list.
-- **Sub-components**: `SearchResultRow` (memo, displays file name, size, seeders/leechers, site link, "Add" button) and `PluginCard` (memo, toggles enable/disable, uninstall).
-- **Normalized types** — `NormalizedSearchPlugin` and `NormalizedSearchResult` decouple from raw qBittorrent API shapes; normalization happens upstream.
+- **Sub-components**: `SearchResultRow` (memo, displays file name, size, seeders/leechers, site link, "Add" button), `SortControl` (memo, `Select` for sort field + button to toggle direction), and `PluginCard` (memo, toggles enable/disable, uninstall).
+- **Normalized types** — `NormalizedSearchPlugin` and `NormalizedSearchResult` decouple from raw qBittorrent API shapes; normalization happens upstream. `SearchSortKey`/`SearchSortDirection` mirror the web-core ordering unions.
+- **Result sorting** — optional `sortKey`/`sortDirection` + `onSortKeyChange`/`onSortDirectionChange` props render the `SortControl` above the results; when any is omitted the control is hidden (backward compatible).
 - **Variant prop** — `variant?: 'desktop' | 'mobile'` adjusts spacing and layout (`isCompact` flag).
 - **Capability gating** — early returns render `StateSurface` for loading/unsupported/offline states before the main UI.
 
@@ -24,6 +25,6 @@ Provides the platform-agnostic presentational body for the qBittorrent search pl
 ## Integration
 
 - **`@taurent/shared`** — `cn`, `formatBytes`, `Icon`.
-- **Local shared components** — `StateSurface`, `SkeletonBlock`, `ConfirmDialog`, `PluginInstallDialog`, `Input`.
+- **Local shared components** — `StateSurface`, `SkeletonBlock`, `ConfirmDialog`, `PluginInstallDialog`, `Input`, `Select`.
 - **Controller layer** — all mutation states (`isPluginActionPending`, `isSearching`, `isLoadingResults`, `isLoadingPlugins`) and action handlers come from the platform controller hook.
-- **Exported from `index.ts`**: `SearchScreenBody`, `SearchScreenProps`, `NormalizedSearchPlugin`, `NormalizedSearchResult`.
+- **Exported from `index.ts`**: `SearchScreenBody`, `SearchScreenProps`, `NormalizedSearchPlugin`, `NormalizedSearchResult`, `SearchSortKey`, `SearchSortDirection`.

--- a/packages/web-ui/src/screens/SearchScreen/index.ts
+++ b/packages/web-ui/src/screens/SearchScreen/index.ts
@@ -3,4 +3,6 @@ export type {
   SearchScreenProps,
   NormalizedSearchPlugin,
   NormalizedSearchResult,
+  SearchSortKey,
+  SearchSortDirection,
 } from './SearchScreenBody';


### PR DESCRIPTION
## Summary

Search results were shown in raw plugin-emission order, which is rarely what a user wants. This adds client-side ordering of search results by **seeders**, **leechers**, **size**, or **name**, with a compact sort control in the shared SearchScreen body. The default is *most seeders first* — the most common torrent-picking heuristic.

- **`packages/web-core/src/search/sortSearchResults.ts`** — new pure, non-mutating ordering helper (`sortSearchResults`) plus `SearchSortKey` / `SearchSortDirection` types and defaults. Numeric fields compare numerically (qBittorrent's `-1` "unknown" sentinel naturally sorts last when descending); names use locale-aware, case-insensitive, digit-aware comparison; the sort is stable.
- **`useSearchController` / `useSearchScreenModel`** — hold `sortKey`/`sortDirection` state (default seeders/desc) and expose the memoized, ordered list through the existing `searchResults` field, so consumers need no changes to read sorted output.
- **`SearchScreenBody`** — new `SortControl` sub-component (a `Select` for the field + a button to flip direction). The sort props are optional, so the control is hidden when a caller doesn't wire them (backward compatible).
- Desktop and mobile SearchScreen wrappers pass the new model fields through; both platforms get the feature from the shared component.
- Codemaps updated for the affected `web-core/search` and `web-ui/SearchScreen` folders.

## Test plan

- [x] `pnpm typecheck` — passes across all 6 projects
- [x] `pnpm lint` — passes across all 6 projects
- [x] `pnpm test:unit` — 922 passed (includes new `sortSearchResults` tests covering each key, both directions, non-mutation, stability, the `-1` sentinel, empty input, and defaults)
- [x] `pnpm --filter taurent-mobile test` — 27 passed
- [ ] Manual: run a search, change the sort field and toggle direction, confirm the result list reorders live

## Notes

Renderer-only change; no Rust/IPC changes. Follows the existing headless-logic-in-web-core + presentational-web-ui boundaries (uses the shared `Select` primitive and semantic theme tokens).