### PR TITLE
fix(e2e): await native app teardown before retry

### DIFF
--- a/apps/desktop/scripts/e2e/infrastructure.test.ts
+++ b/apps/desktop/scripts/e2e/infrastructure.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+import {
+  findAvailablePort,
+  isTcpPortOpen,
+  killAppProcessTree,
+  waitForTcpPortClosed,
+} from './infrastructure.js';
+
+function waitForOutput(child: ChildProcess, expected: string): Promise<void> {
+  return new Promise((resolveReady, rejectReady) => {
+    let stderr = '';
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      child.off('error', onError);
+      child.off('exit', onExit);
+    };
+    const onError = (error: Error): void => {
+      cleanup();
+      rejectReady(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      cleanup();
+      rejectReady(new Error(`Child exited before '${expected}' (code=${code}, signal=${signal}): ${stderr}`));
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      rejectReady(new Error(`Timed out waiting for '${expected}': ${stderr}`));
+    }, 5_000);
+    child.once('error', onError);
+    child.once('exit', onExit);
+    child.stderr?.on('data', (chunk) => { stderr += String(chunk); });
+    child.stdout?.on('data', (chunk) => {
+      if (!String(chunk).includes(expected)) return;
+      cleanup();
+      resolveReady();
+    });
+  });
+}
+
+describe('native E2E process teardown', () => {
+  it('waits for the process to exit and release its WebDriver port', async () => {
+    const port = await findAvailablePort(45_000);
+    const childScript = [
+      "const http = require('node:http')",
+      `const server = http.createServer((_req, res) => res.end('ok')).listen(${port}, '127.0.0.1', () => console.log('ready'))`,
+      "process.on('SIGTERM', () => setTimeout(() => server.close(() => process.exit(0)), 250))",
+    ].join(';');
+    const child = spawn(
+      process.execPath,
+      ['-e', childScript],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+
+    try {
+      await waitForOutput(child, 'ready');
+      expect(await isTcpPortOpen(port)).toBe(true);
+
+      await killAppProcessTree(child, 'unused-test-profile');
+      expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
+      await waitForTcpPortClosed(port, 2_000);
+
+      expect(await isTcpPortOpen(port)).toBe(false);
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+    }
+  }, 10_000);
+});

--- a/apps/desktop/scripts/e2e/infrastructure.ts
+++ b/apps/desktop/scripts/e2e/infrastructure.ts
@@ -74,6 +74,25 @@ export async function findAvailablePort(startPort: number): Promise<number> {
   throw new Error(`No available TCP port found starting at ${startPort}`);
 }
 
+/**
+ * Wait until a TCP listener has released its port.
+ *
+ * Relaunch callers must use this after terminating the previous app. A process
+ * receiving SIGTERM is not guaranteed to exit synchronously, so immediately
+ * spawning its replacement can make the replacement's WebDriver server lose
+ * the bind race with the old process.
+ */
+export async function waitForTcpPortClosed(port: number, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (!(await isTcpPortOpen(port))) return;
+    await sleep(100);
+  }
+
+  throw new Error(`TCP port ${port} was still open ${timeoutMs}ms after process teardown`);
+}
+
 export async function sleep(ms: number): Promise<void> {
   await new Promise((r) => setTimeout(r, ms));
 }
@@ -655,8 +674,9 @@ export async function captureProcessSnapshot(label: string): Promise<ProcessSnap
 /**
  * Kill the Tauri app process and any orphaned WebView2 children.
  *
- * On macOS/Linux, `appProc.kill('SIGTERM')` is sufficient — the OS reaps
- * children. On Windows, `taskkill /F /T /PID <pid>` kills the parent and its
+ * On macOS/Linux, request graceful termination and wait for the process to
+ * exit, escalating to SIGKILL after a bounded timeout. On Windows,
+ * `taskkill /F /T /PID <pid>` kills the parent and its
  * process tree, but WebView2 spawns `msedgewebview2.exe` processes via COM
  * which can survive a tree-kill. We follow up with a PowerShell scan for
  * orphan WebView2 processes whose `CommandLine` references the app's profile
@@ -673,12 +693,45 @@ export async function killAppProcessTree(
     await killAppProcessTreeWindows(appProc, userDataFolder);
     return;
   }
+
+  if (hasChildExited(appProc)) return;
+
   try {
     appProc.kill('SIGTERM');
     writemsg(`[teardown] sent SIGTERM to app process (pid=${appProc.pid ?? '?'})`);
   } catch (err) {
     verbosemsg(`[teardown] SIGTERM failed: ${(err as Error).message}`);
   }
+
+  if (await waitForChildExit(appProc, 5_000)) return;
+
+  writemsg(`[teardown] app process did not exit after SIGTERM; sending SIGKILL (pid=${appProc.pid ?? '?'})`);
+  try {
+    appProc.kill('SIGKILL');
+  } catch (err) {
+    verbosemsg(`[teardown] SIGKILL failed: ${(err as Error).message}`);
+  }
+  await waitForChildExit(appProc, 2_000);
+}
+
+function hasChildExited(appProc: ChildProcess): boolean {
+  return appProc.exitCode !== null || appProc.signalCode !== null;
+}
+
+function waitForChildExit(appProc: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (hasChildExited(appProc)) return Promise.resolve(true);
+
+  return new Promise<boolean>((resolveExit) => {
+    const onExit = (): void => {
+      clearTimeout(timeout);
+      resolveExit(true);
+    };
+    const timeout = setTimeout(() => {
+      appProc.off('exit', onExit);
+      resolveExit(hasChildExited(appProc));
+    }, timeoutMs);
+    appProc.once('exit', onExit);
+  });
 }
 
 async function killAppProcessTreeWindows(

--- a/apps/desktop/scripts/e2e/runner.ts
+++ b/apps/desktop/scripts/e2e/runner.ts
@@ -22,6 +22,7 @@ import {
   captureProcessSnapshot,
   sleep,
   findAvailablePort,
+  waitForTcpPortClosed,
   removeWebviewProfile,
   killAppProcessTree,
   parseSyncDiagnostics,
@@ -500,6 +501,7 @@ async function main() {
     webviewUserDataFolder,
     nativeDiagnosticsLogPath,
   );
+  const appLaunchResults = [appLaunchResult];
   let appProc = appLaunchResult.proc;
 
   try {
@@ -569,6 +571,7 @@ async function main() {
     }
 
     await killAppProcessTree(appProc, webviewUserDataFolder);
+    await waitForTcpPortClosed(driverPort);
     removeWebviewProfile(webviewUserDataFolder);
 
     nativeDiagnosticsLogPath = prepareNativeDiagnosticsLog();
@@ -587,6 +590,7 @@ async function main() {
       webviewUserDataFolder,
       nativeDiagnosticsLogPath,
     );
+    appLaunchResults.push(appLaunchResult);
     appProc = appLaunchResult.proc;
     await waitForAppReady(driverPort);
     result.timings.appLaunchMs = Date.now() - relaunchStart;
@@ -1217,16 +1221,19 @@ async function main() {
     writemsg('Fake server stopped.');
 
     if (!result.success) {
-      printCapturedAppOutputTail(appLaunchResult.capturedStdout, appLaunchResult.capturedStderr);
+      for (const [index, launchResult] of appLaunchResults.entries()) {
+        writemsg(`[diagnostics] app launch attempt ${index + 1}/${appLaunchResults.length}`);
+        printCapturedAppOutputTail(launchResult.capturedStdout, launchResult.capturedStderr);
+      }
     }
 
     result.nativeDiagnostics = readNativeDiagnostics(nativeDiagnosticsLogPath, !result.success);
 
     // Parse sync evidence from captured app output (T147.1 diagnostics)
-    const allAppLines = [
-      ...appLaunchResult.capturedStdout.join('').split('\n'),
-      ...appLaunchResult.capturedStderr.join('').split('\n'),
-    ].filter(Boolean);
+    const allAppLines = appLaunchResults.flatMap((launchResult) => [
+      ...launchResult.capturedStdout.join('').split('\n'),
+      ...launchResult.capturedStderr.join('').split('\n'),
+    ]).filter(Boolean);
     result.syncDiagnostics = parseSyncDiagnostics(allAppLines);
     writemsg(
       `[sync-diagnostics] snapshots=${result.syncDiagnostics.snapshotTimings.length}` +

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react';
 import { playwright } from '@vitest/browser-playwright';
 import path from 'path';
 
+const isBrowserRun = process.argv.some((arg) => arg === '--browser' || arg.startsWith('--browser='));
+const testIncludes = isBrowserRun
+  ? ['src/**/*.test.ts', 'src/**/*.test.tsx']
+  : ['src/**/*.test.ts', 'src/**/*.test.tsx', 'scripts/**/*.test.ts'];
+
 export default defineProject({
   plugins: [react()],
   resolve: {
@@ -21,6 +26,6 @@ export default defineProject({
       provider: playwright(),
       instances: [{ browser: 'chromium' }],
     },
-    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    include: testIncludes,
   },
 });


### PR DESCRIPTION
## Summary

- wait for the native Tauri process to exit before retrying WebDriver startup
- require the previous WebDriver port to be released before relaunch
- preserve stdout/stderr from every launch attempt for useful CI diagnostics
- add a delayed-SIGTERM regression test for process and port teardown

## Root cause

The Linux retry path sent `SIGTERM` and immediately started a replacement app. The previous Tauri instance could still own the single-instance registration or WebDriver port, causing the replacement to lose startup state and time out. Earlier fixes expanded the set of errors considered recoverable but did not make teardown synchronous.

This addresses the recurring Desktop Tauri Smoke failure seen in [Actions run 29369224425](https://github.com/racos-dev/taurent/actions/runs/29369224425/job/87209003284).

## Validation

- `pnpm ci:local` (40 files, 913 tests)
- desktop ESLint and TypeScript checks
- focused native runner lifecycle test with delayed `SIGTERM` shutdown
- repository pre-commit checks, including Rust formatting
