### PR TITLE
fix: open external links in system browser via ExternalLink component

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, useRef } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, createBrowserRouter, Outlet } from 'react-router-dom';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { QBClientProvider } from './connection';
 import { ServerManagerProvider } from './connection/ServerManager';
 import { AppShell } from './layouts/AppShell/AppShell';
@@ -26,6 +27,7 @@ import { useFocusSearch } from './contexts/useSearchFocusHooks';
 import { mark } from '@taurent/shared/utils/perfAudit';
 import { Toaster } from '@taurent/web-ui/components/shared/Toast/Toaster';
 import { toast } from '@taurent/web-ui/components/shared/Toast/toast';
+import { ExternalLinkProvider } from '@taurent/web-ui';
 import { useOperationNotifications } from '@taurent/web-core/hooks/useOperationNotifications';
 import { notifyNative } from '@taurent/bridge/desktop/notification';
 
@@ -162,16 +164,18 @@ function AppContent() {
   }, []);
 
   return (
-    <SearchFocusProvider>
-      <ThemeProvider defaultTheme="catppuccin">
-        <ServerManagerProvider>
-          <QBClientProvider>
-            <AppNotifications />
-            <RouterProvider router={router} />
-          </QBClientProvider>
-        </ServerManagerProvider>
-      </ThemeProvider>
-    </SearchFocusProvider>
+    <ExternalLinkProvider onNavigate={url => void openUrl(url)}>
+      <SearchFocusProvider>
+        <ThemeProvider defaultTheme="catppuccin">
+          <ServerManagerProvider>
+            <QBClientProvider>
+              <AppNotifications />
+              <RouterProvider router={router} />
+            </QBClientProvider>
+          </ServerManagerProvider>
+        </ThemeProvider>
+      </SearchFocusProvider>
+    </ExternalLinkProvider>
   );
 }
 

--- a/apps/desktop/src/components/AppUpdateBanner.tsx
+++ b/apps/desktop/src/components/AppUpdateBanner.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { BridgeAdapter } from '@taurent/bridge/adapters/desktop';
 import type { AppUpdateInfo, AppUpdateProgress } from '@taurent/bridge/contracts';
-import { Button, ProgressBar } from '@taurent/web-ui';
+import { Button, ProgressBar, useExternalLinkHandler } from '@taurent/web-ui';
 
 const RELEASE_URL = 'https://github.com/racos-dev/taurent/releases/latest';
 
@@ -69,9 +69,15 @@ export function AppUpdateBanner() {
     }
   }, []);
 
+  const onNavigate = useExternalLinkHandler();
+
   const handleRelease = useCallback(() => {
-    window.open(RELEASE_URL, '_blank', 'noopener,noreferrer');
-  }, []);
+    if (onNavigate) {
+      onNavigate(RELEASE_URL);
+    } else {
+      window.open(RELEASE_URL, '_blank', 'noopener,noreferrer');
+    }
+  }, [onNavigate]);
 
   const copy = useMemo(() => {
     if (state.status === 'hidden') return null;

--- a/apps/desktop/src/components/Settings/DesktopAboutSettings.tsx
+++ b/apps/desktop/src/components/Settings/DesktopAboutSettings.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 
 import { BridgeAdapter } from '@taurent/bridge/adapters/desktop';
 import type { AppUpdateInfo, AppUpdateProgress } from '@taurent/bridge/contracts';
-import { Button, ProgressBar } from '@taurent/web-ui';
+import { Button, ExternalLink, ProgressBar } from '@taurent/web-ui';
 import { appBuildMetadata } from '../../buildMetadata';
 
 type UpdateSettingsState =
@@ -98,14 +98,12 @@ export const DesktopAboutSettings = React.memo(() => {
         <p className="mt-2 text-xs text-text-muted">
           Built by racos.dev
         </p>
-        <a
+        <ExternalLink
           href="https://github.com/racos-dev/taurent"
-          target="_blank"
-          rel="noopener noreferrer"
           className="mt-2 text-xs font-medium text-primary hover:underline"
         >
           View on GitHub
-        </a>
+        </ExternalLink>
       </div>
       <div className="mt-4 border-t border-border pt-3">
         <div className="flex flex-col gap-3">
@@ -124,14 +122,12 @@ export const DesktopAboutSettings = React.memo(() => {
           <div className="flex flex-wrap justify-center gap-2">
             {updateState.status === 'available' ? (
               <>
-                <a
+                <ExternalLink
                   href={RELEASE_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
                   className="inline-flex h-9 items-center rounded-sm px-3 text-xs font-medium text-primary hover:underline"
                 >
                   View release
-                </a>
+                </ExternalLink>
                 <Button variant="primary" size="sm" onClick={() => void handleInstall(updateState.update)}>
                   Update
                 </Button>

--- a/packages/web-ui/src/components/shared/ExternalLink.tsx
+++ b/packages/web-ui/src/components/shared/ExternalLink.tsx
@@ -1,0 +1,61 @@
+import React, { createContext, useCallback, useContext } from 'react';
+
+export interface ExternalLinkProps {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+interface ExternalLinkContextValue {
+  onNavigate: ((url: string) => void) | null;
+}
+
+const ExternalLinkContext = createContext<ExternalLinkContextValue>({ onNavigate: null });
+
+export interface ExternalLinkProviderProps {
+  onNavigate: (url: string) => void;
+  children: React.ReactNode;
+}
+
+export const ExternalLinkProvider = React.memo(({ onNavigate, children }: ExternalLinkProviderProps) => {
+  return (
+    <ExternalLinkContext.Provider value={{ onNavigate }}>
+      {children}
+    </ExternalLinkContext.Provider>
+  );
+});
+
+ExternalLinkProvider.displayName = 'ExternalLinkProvider';
+
+export function useExternalLinkHandler(): ((url: string) => void) | null {
+  return useContext(ExternalLinkContext).onNavigate;
+}
+
+export const ExternalLink = React.memo(({ href, children, className }: ExternalLinkProps) => {
+  const onNavigate = useExternalLinkHandler();
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (!onNavigate) return;
+      e.preventDefault();
+      onNavigate(href);
+    },
+    [href, onNavigate],
+  );
+
+  if (onNavigate) {
+    return (
+      <button type="button" onClick={handleClick} className={className}>
+        {children}
+      </button>
+    );
+  }
+
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
+      {children}
+    </a>
+  );
+});
+
+ExternalLink.displayName = 'ExternalLink';

--- a/packages/web-ui/src/index.ts
+++ b/packages/web-ui/src/index.ts
@@ -224,6 +224,8 @@ export { StateSurface } from './components/shared/StateSurface';
 export type { StateSurfaceProps, StateSurfaceTone } from './components/shared/StateSurface';
 export { SkeletonBlock } from './components/shared/SkeletonBlock';
 export type { SkeletonBlockProps, SkeletonBlockRadius } from './components/shared/SkeletonBlock';
+export { ExternalLink, ExternalLinkProvider, useExternalLinkHandler } from './components/shared/ExternalLink';
+export type { ExternalLinkProps, ExternalLinkProviderProps } from './components/shared/ExternalLink';
 export { Spinner } from './components/shared/Spinner';
 export type { SpinnerProps, SpinnerSize, SpinnerVariant } from './components/shared/Spinner';
 export { RetryButton } from './components/shared/RetryButton';

--- a/packages/web-ui/src/screens/RSSScreen/RSSScreenBody.tsx
+++ b/packages/web-ui/src/screens/RSSScreen/RSSScreenBody.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { cn, Icon, Edit2, Trash2 } from '@taurent/shared';
 import { TabBar } from '@taurent/web-ui';
+import { ExternalLink } from '../../components/shared/ExternalLink';
 import { StateSurface } from '../../components/shared/StateSurface';
 import { InfoRow } from '../../components/shared/InfoRow';
 import { SkeletonBlock } from '../../components/shared/SkeletonBlock';
@@ -116,15 +117,13 @@ const RSSItemRow = React.memo<RSSItemRowProps>(({ item, onEditFeedUrl, onRemoveI
           )}
       </div>
       {item.url && (
-        <a
+        <ExternalLink
           href={item.url}
-          target="_blank"
-          rel="noopener noreferrer"
           className="mt-1 flex items-center gap-1 text-xs text-primary hover:underline"
         >
           <Icon name="external-link" className="h-3 w-3" />
           {item.url}
-        </a>
+        </ExternalLink>
       )}
     </div>
     {!item.isFolder && (

--- a/packages/web-ui/src/screens/SearchScreen/SearchScreenBody.tsx
+++ b/packages/web-ui/src/screens/SearchScreen/SearchScreenBody.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { cn, formatBytes, Icon } from '@taurent/shared';
+import { ExternalLink } from '../../components/shared/ExternalLink';
 import { StateSurface } from '../../components/shared/StateSurface';
 import { SkeletonBlock } from '../../components/shared/SkeletonBlock';
 import { ConfirmDialog } from '../../components/dialogs/ConfirmDialog';
@@ -126,16 +127,13 @@ const SearchResultRow = React.memo<SearchResultRowProps>(({ result, onAdd }) => 
         <span>Leechers: {result.nbLeechers}</span>
       </div>
       {result.siteUrl ? (
-        <a
+        <ExternalLink
           href={result.siteUrl}
-          target="_blank"
-          rel="noopener noreferrer"
           className="mt-1 flex items-center gap-1 text-xs text-primary hover:underline"
-          onClick={(e) => { e.stopPropagation(); }}
         >
           <Icon name="external-link" className="h-3 w-3" />
           {result.siteUrl}
-        </a>
+        </ExternalLink>
       ) : null}
     </div>
   </div>
@@ -202,15 +200,13 @@ const PluginCard = React.memo<PluginCardProps>(({ plugin, isEnabled, onToggle, o
         ) : null}
       </div>
       {plugin.url ? (
-        <a
+        <ExternalLink
           href={plugin.url}
-          target="_blank"
-          rel="noopener noreferrer"
           className="mt-1 flex items-center gap-1 text-xs text-primary hover:underline"
         >
           <Icon name="external-link" className="h-3 w-3" />
           {plugin.url}
-        </a>
+        </ExternalLink>
       ) : null}
     </div>
     <div className="flex items-center gap-2">


### PR DESCRIPTION
Replaces raw <a target="_blank"> and window.open() with a reusable ExternalLink component that uses @tauri-apps/plugin-opener when running inside Tauri (desktop), falling back to standard browser behavior.

- Add ExternalLink + ExternalLinkProvider in @taurent/web-ui
- Wire ExternalLinkProvider in desktop App.tsx with openUrl
- Update DesktopAboutSettings, AppUpdateBanner, SearchScreenBody, and RSSScreenBody to use the new component