### PR TITLE
Fix desktop category and tag context menus

### DIFF
--- a/apps/desktop/e2e/torrent-commands.spec.ts
+++ b/apps/desktop/e2e/torrent-commands.spec.ts
@@ -302,6 +302,13 @@ test.describe('desktop torrent commands', () => {
   });
 
   test('opens the category create flow and assigns or resets category from the main window', async ({ page }) => {
+    const duplicateKeyWarnings: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error' && message.text().includes('same key')) {
+        duplicateKeyWarnings.push(message.text());
+      }
+    });
+
     await loadMainWindow(page);
     const firstRow = getFirstVisibleTorrentRow(page);
     const expectedHash = await readRequiredTorrentRowHash(firstRow);
@@ -315,10 +322,16 @@ test.describe('desktop torrent commands', () => {
     await clearAutomationState(page);
     await openContextMenuForRow(firstRow, page);
     await hoverMenuItem(page, 'Category');
-    await clickSubMenuItem(page, 'videos');
+    await clickSubMenuItem(page, 'new');
 
     let call = await expectRecordedCall(page, 'torrents.setCategory');
-    expect(call.args).toEqual([[expectedHash], 'videos']);
+    expect(call.args).toEqual([[expectedHash], 'new']);
+    expect(duplicateKeyWarnings).toEqual([]);
+    await expect(mainMenu(page)).toBeVisible();
+    await expect(subMenu(page)).toBeVisible();
+
+    await page.mouse.click(4, 4);
+    await expect(mainMenu(page)).toBeHidden();
 
     await clearAutomationState(page);
     await openContextMenuForRow(firstRow, page);
@@ -327,6 +340,8 @@ test.describe('desktop torrent commands', () => {
 
     call = await expectRecordedCall(page, 'torrents.setCategory');
     expect(call.args).toEqual([[expectedHash], '']);
+    await expect(mainMenu(page)).toBeVisible();
+    await expect(subMenu(page)).toBeVisible();
   });
 
   test('opens the tag create flow from the main window', async ({ page }) => {
@@ -338,6 +353,35 @@ test.describe('desktop torrent commands', () => {
     await clickSubMenuItem(page, 'Add...');
 
     await waitForMockWebview(page, { dialog: 'create', type: 'tag' });
+  });
+
+  test('toggles torrent tags without dismissing the context menu', async ({ page }) => {
+    await loadMainWindow(page);
+    const row = getFirstVisibleTorrentRow(page);
+    const expectedHash = await readRequiredTorrentRowHash(row);
+
+    await openContextMenuForRow(row, page);
+    await hoverMenuItem(page, 'Tags');
+    await clickSubMenuItem(page, 'tag-a');
+
+    await expect
+      .poll(async () => {
+        const calls = await readRecordedCalls(page);
+        return calls.find((entry) =>
+          entry.name === 'tags.addTorrentTags' || entry.name === 'tags.removeTorrentTags'
+        ) ?? null;
+      })
+      .not.toBeNull();
+    const calls = await readRecordedCalls(page);
+    const tagMutation = calls.find((entry) =>
+      entry.name === 'tags.addTorrentTags' || entry.name === 'tags.removeTorrentTags'
+    );
+    expect(tagMutation?.args).toEqual([[expectedHash], ['tag-a']]);
+    await expect(mainMenu(page)).toBeVisible();
+    await expect(subMenu(page)).toBeVisible();
+
+    await page.mouse.click(4, 4);
+    await expect(mainMenu(page)).toBeHidden();
   });
 
   test('opens the per-torrent limit dialogs from the main window and submits each mutation', async ({ page }) => {

--- a/apps/desktop/e2e/torrent-commands.spec.ts
+++ b/apps/desktop/e2e/torrent-commands.spec.ts
@@ -107,12 +107,7 @@ async function clickSubMenuItem(page: Page, label: string) {
   await expect(subMenu(page)).toBeVisible({ timeout: 5_000 });
   const item = subMenu(page).getByRole('menuitem', { name: label, exact: true });
   await expect(item).toBeEnabled();
-  await item.evaluate((element) => {
-    if (!(element instanceof HTMLButtonElement)) {
-      throw new Error('Expected submenu item to render as a button.');
-    }
-    element.click();
-  });
+  await item.click();
 }
 
 async function readRequiredTorrentRowHash(row: Locator): Promise<string> {

--- a/apps/desktop/src/components/TorrentContextMenu.tsx
+++ b/apps/desktop/src/components/TorrentContextMenu.tsx
@@ -331,17 +331,18 @@ export function TorrentContextMenu({
       label: 'Category',
       icon: FolderOpen,
       children: [
-        { kind: 'item', id: 'cat-new', label: 'New...', disabled: !hasSelection, onClick: () => openDialog('newCategory') },
-        { kind: 'item', id: 'cat-reset', label: 'Reset', disabled: !canResetCategory, onClick: () => { setTorrentCategory.mutate({ hashes: selectionHashes, category: '' }); onClose(); } },
+        { kind: 'item', id: 'category-action-new', label: 'New...', disabled: !hasSelection, onClick: () => openDialog('newCategory') },
+        { kind: 'item', id: 'category-action-reset', label: 'Reset', disabled: !canResetCategory, closeOnSelect: false, onClick: () => { setTorrentCategory.mutate({ hashes: selectionHashes, category: '' }); } },
         ...(activeCategoryList.length > 0
           ? [
-              { kind: 'separator' as const, id: 'cat-sep' },
+              { kind: 'separator' as const, id: 'category-separator' },
               ...activeCategoryList.map((cat) => ({
                 kind: 'item' as const,
-                id: `cat-${cat}`,
+                id: `category-option-${encodeURIComponent(cat)}`,
                 label: cat,
                 icon: currentCategory === cat ? CheckIcon : undefined,
-                onClick: () => { setTorrentCategory.mutate({ hashes: selectionHashes, category: cat }); onClose(); },
+                closeOnSelect: false,
+                onClick: () => { setTorrentCategory.mutate({ hashes: selectionHashes, category: cat }); },
               })),
             ]
           : []),
@@ -355,17 +356,18 @@ export function TorrentContextMenu({
       label: 'Tags',
       icon: Tag,
       children: [
-        { kind: 'item', id: 'tag-add', label: 'Add...', disabled: !hasSelection, onClick: () => openDialog('addTag') },
-        { kind: 'item', id: 'tag-remove-all', label: 'Remove All', disabled: allTagsInSelection.size === 0, onClick: () => { if (allTagsInSelection.size > 0) { removeTorrentTags.mutate({ hashes: selectionHashes, tags: Array.from(allTagsInSelection) }); onClose(); } } },
+        { kind: 'item', id: 'tag-action-add', label: 'Add...', disabled: !hasSelection, onClick: () => openDialog('addTag') },
+        { kind: 'item', id: 'tag-action-remove-all', label: 'Remove All', disabled: allTagsInSelection.size === 0, closeOnSelect: false, onClick: () => { if (allTagsInSelection.size > 0) { removeTorrentTags.mutate({ hashes: selectionHashes, tags: Array.from(allTagsInSelection) }); } } },
         ...(tags && tags.length > 0
           ? [
-              { kind: 'separator' as const, id: 'tag-sep' },
+              { kind: 'separator' as const, id: 'tag-separator' },
               ...tags.map((tag) => ({
                 kind: 'item' as const,
-                id: `tag-${tag}`,
+                id: `tag-option-${encodeURIComponent(tag)}`,
                 label: tag,
                 icon: sharedTags.includes(tag) ? CheckIcon : undefined,
-                onClick: () => { if (sharedTags.includes(tag)) { removeTorrentTags.mutate({ hashes: selectionHashes, tags: [tag] }); } else { addTorrentTags.mutate({ hashes: selectionHashes, tags: [tag] }); } onClose(); },
+                closeOnSelect: false,
+                onClick: () => { if (sharedTags.includes(tag)) { removeTorrentTags.mutate({ hashes: selectionHashes, tags: [tag] }); } else { addTorrentTags.mutate({ hashes: selectionHashes, tags: [tag] }); } },
               })),
             ]
           : []),
@@ -431,7 +433,7 @@ export function TorrentContextMenu({
   ], [
     isSingle, selectionHashes, resumeCmd, pauseCmd, forceStartCmd, deleteCmd, handleAction,
     canSetLocation, canRename, openDialog, hasSelection, canResetCategory, setTorrentCategory,
-    onClose, activeCategoryList, currentCategory, tags, allTagsInSelection, addTorrentTags,
+    activeCategoryList, currentCategory, tags, allTagsInSelection, addTorrentTags,
     removeTorrentTags, sharedTags, hasService, handleToggleAutoTmm, isAutoTmmEnabled,
     hasIncompleteSelection, canSetDownloadLimit, canSetUploadLimit,
     isDownloadingSelection, isMixedDownloadingAndSeedingSelection,

--- a/apps/desktop/src/testing/mockDesktopBridge.ts
+++ b/apps/desktop/src/testing/mockDesktopBridge.ts
@@ -1308,7 +1308,11 @@ function createMockBridge(): DesktopBridge {
       getCategories() {
         return Promise.resolve({
           session_generation: GEN, server_id: 'mock-server-id',
-          categories: { videos: { name: 'videos', savePath: '/data/videos' }, audio: { name: 'audio', savePath: '/data/audio' } },
+          categories: {
+            videos: { name: 'videos', savePath: '/data/videos' },
+            audio: { name: 'audio', savePath: '/data/audio' },
+            new: { name: 'new', savePath: '/data/new' },
+          },
         });
       },
       createCategory(name: string, savePath: string) {
@@ -1346,8 +1350,14 @@ function createMockBridge(): DesktopBridge {
         recordCall('tags.deleteTags', [tags]);
         return Promise.resolve(OK());
       },
-      addTorrentTags() { return Promise.resolve(OK()); },
-      removeTorrentTags() { return Promise.resolve(OK()); },
+      addTorrentTags(hashes: string[], tags: string[]) {
+        recordCall('tags.addTorrentTags', [hashes, tags]);
+        return Promise.resolve(OK());
+      },
+      removeTorrentTags(hashes: string[], tags: string[]) {
+        recordCall('tags.removeTorrentTags', [hashes, tags]);
+        return Promise.resolve(OK());
+      },
     },
 
     // ── Application ──────────────────────────────────────────────────────────

--- a/packages/web-ui/src/components/primitives/ContextMenu/ContextMenu.test.tsx
+++ b/packages/web-ui/src/components/primitives/ContextMenu/ContextMenu.test.tsx
@@ -1,0 +1,74 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ContextMenu } from './ContextMenu';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('ContextMenu', () => {
+  it('keeps a toggle-style submenu item open until an outside click', () => {
+    vi.useFakeTimers();
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    const { getByRole } = render(
+      <ContextMenu
+        x={16}
+        y={16}
+        onClose={onClose}
+        items={[
+          {
+            kind: 'submenu',
+            id: 'labels',
+            label: 'Labels',
+            children: [
+              {
+                kind: 'item',
+                id: 'label-option',
+                label: 'Label A',
+                closeOnSelect: false,
+                onClick: onSelect,
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.mouseEnter(getByRole('menuitem', { name: 'Labels' }));
+    act(() => vi.advanceTimersByTime(100));
+    fireEvent.click(getByRole('menuitem', { name: 'Label A' }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(getByRole('menuitem', { name: 'Label A' })).toBeTruthy();
+
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('still closes ordinary items after selection', () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    const { getByRole } = render(
+      <ContextMenu
+        x={16}
+        y={16}
+        onClose={onClose}
+        items={[
+          {
+            kind: 'item',
+            id: 'ordinary-action',
+            label: 'Ordinary action',
+            onClick: onSelect,
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(getByRole('menuitem', { name: 'Ordinary action' }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web-ui/src/components/primitives/ContextMenu/ContextMenu.test.tsx
+++ b/packages/web-ui/src/components/primitives/ContextMenu/ContextMenu.test.tsx
@@ -37,7 +37,9 @@ describe('ContextMenu', () => {
 
     fireEvent.mouseEnter(getByRole('menuitem', { name: 'Labels' }));
     act(() => vi.advanceTimersByTime(100));
-    fireEvent.click(getByRole('menuitem', { name: 'Label A' }));
+    const toggleItem = getByRole('menuitem', { name: 'Label A' });
+    expect(fireEvent.mouseDown(toggleItem)).toBe(false);
+    fireEvent.click(toggleItem);
 
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onClose).not.toHaveBeenCalled();

--- a/packages/web-ui/src/components/primitives/ContextMenu/ContextMenu.tsx
+++ b/packages/web-ui/src/components/primitives/ContextMenu/ContextMenu.tsx
@@ -76,6 +76,7 @@ function renderSubMenuChild(item: TContextMenuItem, onClose: () => void): React.
       shortcut={item.shortcut}
       disabled={item.disabled}
       destructive={item.destructive}
+      closeOnSelect={item.closeOnSelect}
       onClick={() => {
         item.onClick();
         if (item.closeOnSelect !== false) onClose();
@@ -162,6 +163,7 @@ export function ContextMenu({ x, y, items, onClose, className, width = 'w-48' }:
                         shortcut={child.shortcut}
                         disabled={child.disabled}
                         destructive={child.destructive}
+                        closeOnSelect={child.closeOnSelect}
                         onClick={() => {
                           child.onClick();
                           if (child.closeOnSelect !== false) onClose();
@@ -203,6 +205,7 @@ export function ContextMenu({ x, y, items, onClose, className, width = 'w-48' }:
               shortcut={item.shortcut}
               disabled={item.disabled}
               destructive={item.destructive}
+              closeOnSelect={item.closeOnSelect}
               onClick={() => {
                 item.onClick();
                 if (item.closeOnSelect !== false) onClose();

--- a/packages/web-ui/src/components/primitives/ContextMenu/ContextMenu.tsx
+++ b/packages/web-ui/src/components/primitives/ContextMenu/ContextMenu.tsx
@@ -78,7 +78,7 @@ function renderSubMenuChild(item: TContextMenuItem, onClose: () => void): React.
       destructive={item.destructive}
       onClick={() => {
         item.onClick();
-        onClose();
+        if (item.closeOnSelect !== false) onClose();
       }}
     />
   );
@@ -164,7 +164,7 @@ export function ContextMenu({ x, y, items, onClose, className, width = 'w-48' }:
                         destructive={child.destructive}
                         onClick={() => {
                           child.onClick();
-                          onClose();
+                          if (child.closeOnSelect !== false) onClose();
                         }}
                         ref={ref as React.Ref<HTMLButtonElement>}
                       />
@@ -205,7 +205,7 @@ export function ContextMenu({ x, y, items, onClose, className, width = 'w-48' }:
               destructive={item.destructive}
               onClick={() => {
                 item.onClick();
-                onClose();
+                if (item.closeOnSelect !== false) onClose();
               }}
               ref={ref as React.Ref<HTMLButtonElement>}
             />

--- a/packages/web-ui/src/components/primitives/ContextMenu/ContextMenuItem.tsx
+++ b/packages/web-ui/src/components/primitives/ContextMenu/ContextMenuItem.tsx
@@ -15,6 +15,8 @@ interface ContextMenuItemProps {
   destructive?: boolean;
   /** Highlights the item as keyboard-active. */
   active?: boolean;
+  /** Whether selecting the item dismisses its composed context menu. */
+  closeOnSelect?: boolean;
   /** Invoked on click. */
   onClick?: () => void;
   /** Attached to the native `onMouseEnter` event. */
@@ -33,6 +35,7 @@ export const ContextMenuItem = forwardRef<HTMLButtonElement, ContextMenuItemProp
       disabled = false,
       destructive = false,
       active = false,
+      closeOnSelect = true,
       onClick,
       onMouseEnter,
       onMouseLeave,
@@ -48,6 +51,7 @@ export const ContextMenuItem = forwardRef<HTMLButtonElement, ContextMenuItemProp
         aria-label={label}
         aria-disabled={disabled}
         disabled={disabled}
+        onMouseDown={disabled || closeOnSelect ? undefined : (event) => event.preventDefault()}
         onClick={disabled ? undefined : onClick}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}

--- a/packages/web-ui/src/components/primitives/ContextMenu/ContextMenuSubMenu.tsx
+++ b/packages/web-ui/src/components/primitives/ContextMenu/ContextMenuSubMenu.tsx
@@ -237,7 +237,9 @@ export function ContextMenuSubMenu({
   );
 
   const handlePanelBlur = useCallback(
-    (_e: React.FocusEvent<HTMLDivElement>) => {
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      const nextFocus = e.relatedTarget;
+      if (nextFocus instanceof Node && e.currentTarget.contains(nextFocus)) return;
       setIsOpen(false);
     },
     []

--- a/packages/web-ui/src/components/primitives/ContextMenu/codemap.md
+++ b/packages/web-ui/src/components/primitives/ContextMenu/codemap.md
@@ -6,7 +6,7 @@ Full-featured context menu system with items, separators, groups, nested submenu
 
 ## Design
 
-- **ContextMenu**: Top-level composed component. Maps `ContextMenuItem[]` (union of item/separator/group/submenu types) to appropriate sub-components.
+- **ContextMenu**: Top-level composed component. Maps `ContextMenuItem[]` (union of item/separator/group/submenu types) to appropriate sub-components. Toggle-style items can set `closeOnSelect: false` to remain open until an outside click or Escape.
 - **useContextMenu**: Hook managing `activeIndex`, `panelPosition`, `panelRef`, `registerItemRef`, and `handlePanelBlur`. Handles viewport clamping and keyboard navigation.
 - **ContextMenuPanel**: Portal-based positioned panel (similar to `DropdownPanel`).
 - **ContextMenuItem**: Single menu item with icon, label, shortcut, and destructive styling. Uses `forwardRef` for keyboard navigation integration.
@@ -20,7 +20,7 @@ Full-featured context menu system with items, separators, groups, nested submenu
 1. Parent provides `x`, `y` (click coordinates), `items[]`, and `onClose`.
 2. `ContextMenu` wires `useContextMenu` hook and renders `ContextMenuPanel`.
 3. Items are mapped to appropriate sub-components based on `kind` discriminator.
-4. Click/Enter triggers `item.onClick()` + `onClose()`. Escape dismisses.
+4. Click/Enter triggers `item.onClick()` and, by default, `onClose()`. Items with `closeOnSelect: false` remain open. Escape dismisses.
 
 ## Integration
 

--- a/packages/web-ui/src/components/primitives/ContextMenu/codemap.md
+++ b/packages/web-ui/src/components/primitives/ContextMenu/codemap.md
@@ -9,7 +9,7 @@ Full-featured context menu system with items, separators, groups, nested submenu
 - **ContextMenu**: Top-level composed component. Maps `ContextMenuItem[]` (union of item/separator/group/submenu types) to appropriate sub-components. Toggle-style items can set `closeOnSelect: false` to remain open until an outside click or Escape.
 - **useContextMenu**: Hook managing `activeIndex`, `panelPosition`, `panelRef`, `registerItemRef`, and `handlePanelBlur`. Handles viewport clamping and keyboard navigation.
 - **ContextMenuPanel**: Portal-based positioned panel (similar to `DropdownPanel`).
-- **ContextMenuItem**: Single menu item with icon, label, shortcut, and destructive styling. Uses `forwardRef` for keyboard navigation integration.
+- **ContextMenuItem**: Single menu item with icon, label, shortcut, and destructive styling. Uses `forwardRef` for keyboard navigation integration. Non-dismissing items preserve focus on mouse down so submenu blur cannot unmount them before their click handler runs.
 - **ContextMenuSeparator**: Separator line with optional label.
 - **ContextMenuGroup**: Grouped items under a shared heading.
 - **ContextMenuSubMenu**: Expandable submenu with child items. Renders flyout via `createPortal`, with viewport-aware placement, keyboard navigation (ArrowRight/ArrowLeft), and mouse hover delay (80ms open timer).

--- a/packages/web-ui/src/components/primitives/ContextMenu/types.ts
+++ b/packages/web-ui/src/components/primitives/ContextMenu/types.ts
@@ -18,6 +18,8 @@ export interface ContextMenuItemType {
   shortcut?: string;
   disabled?: boolean;
   destructive?: boolean;
+  /** Keep the menu open after selection. Useful for toggle-style items. */
+  closeOnSelect?: boolean;
   onClick: () => void;
 }
 

--- a/packages/web-ui/src/components/primitives/ContextMenu/useContextMenu.ts
+++ b/packages/web-ui/src/components/primitives/ContextMenu/useContextMenu.ts
@@ -138,7 +138,7 @@ export function useContextMenu({
           const activeItem = navigable.find(({ index }) => index === activeIndex);
           if (activeItem && activeItem.item.kind === 'item') {
             onSelect(activeItem.item);
-            onClose();
+            if (activeItem.item.closeOnSelect !== false) onClose();
           }
           break;
         }


### PR DESCRIPTION
## Summary

- prevent category and tag submenu item IDs from colliding with fixed action IDs
- keep category and tag toggle selections open until the user clicks outside or presses Escape
- preserve normal dismissal for ordinary context-menu actions and dialog launchers
- fix submenu blur handling so focus movement inside the flyout does not dismiss it
- add unit and desktop renderer regression coverage for category assignment, tag toggling, and duplicate-key warnings

## Root cause

Dynamic category and tag IDs shared the same namespace as fixed menu action IDs. A category named `new` therefore collided with the fixed `cat-new` item, causing React reconciliation warnings and unsupported click behavior. The shared context-menu implementation also unconditionally dismissed every selected item and treated internal submenu focus changes as blur dismissal.

## User impact

Desktop users can now assign torrents to categories and toggle tags reliably. These selection-style actions keep the menu visible for further changes and close only through outside interaction or Escape.

## Validation

- pre-commit version checks, capability codegen, tray icon check, Rust formatting, and workspace lint
- pre-push `pnpm ci:local`
- 41 unit test files passed, 905 tests total
- focused desktop Playwright category and tag context-menu tests passed
- focused ContextMenu unit tests passed
