### PR TITLE
ci: bootstrap Node before pnpm on Fedora

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -230,17 +230,15 @@ jobs:
         with:
           ref: ${{ needs.release-preflight.outputs.release_tag }}
 
-      - name: Enable pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        with:
-          standalone: true
-
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Enable pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          standalone: true
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@0a0b1db3a4e40d68af9ce1f11281259916528f39 # 1.90.0


### PR DESCRIPTION
## Summary

- set up Node before `pnpm/action-setup` in the Fedora release container
- keep standalone pnpm installation, but drop setup-node's pnpm cache for this one packaging lane

## Root cause

`pnpm/action-setup` runs its self-installer with `npm ci` even when `standalone: true`. The minimal Fedora container has no npm until `actions/setup-node` runs, so pnpm setup failed with `spawn npm ENOENT`.

## Validation

- confirmed the failure in release run `30407958722`, Fedora job `90437607564`
- `actionlint` v1.7.12
- pre-commit checks
- `pnpm ci:local`
