### PR TITLE
fix(ci): keep CodeQL actions in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      codeql-actions:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,12 +29,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- update both `github/codeql-action/init` and `github/codeql-action/analyze` to the same pinned 4.37.7 commit
- group `github/codeql-action/*` updates in Dependabot so future CodeQL releases are proposed together

## Root cause

Dependabot opened separate PRs for the `init` and `analyze` action subpaths. CodeQL persists version-specific configuration between those steps, so each isolated update caused the workflow to mix 4.37.3 and 4.37.7 and fail both analysis jobs.

This supersedes #72 and #73.

## Validation

- YAML parsing for `.github/workflows/codeql.yml` and `.github/dependabot.yml`
- `git diff --check`
- repository pre-commit checks: version consistency, capability codegen, Rust formatting, workspace lint
- repository pre-push `pnpm ci:local`: script tests, lint, typecheck, unit tests, and mobile tests
